### PR TITLE
feat(postgrest): add opt-in retry option (#297)

### DIFF
--- a/packages/Postgrest/Postgrest.Tests/Requests/RetryTests.cs
+++ b/packages/Postgrest/Postgrest.Tests/Requests/RetryTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Core.Http;
+using Supabase.Postgrest;
+using Supabase.Postgrest.Attributes;
+using Supabase.Postgrest.Exceptions;
+using Supabase.Postgrest.Models;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Postgrest.Tests.Requests;
+
+/// <summary>
+///     <see cref="ClientOptions.Retry" /> reaching the transport: a 503 is retried with a fresh body, and
+///     the default options don't retry.
+/// </summary>
+[TestClass]
+[TestCategory("Contract")]
+public class RetryTests
+{
+    private static readonly RetryOptions RetryOnce = new() { MaxRetries = 1, BaseDelay = TimeSpan.FromMilliseconds(1), UseJitter = false };
+
+    private WireMockServer server = null!;
+
+    [Table("todos")]
+    private class Todo : BaseModel
+    {
+        [PrimaryKey("id")] public int Id { get; set; }
+        [Column("name")] public string? Name { get; set; }
+    }
+
+    [TestInitialize]
+    public void SetUp() => this.server = WireMockServer.Start();
+
+    [TestCleanup]
+    public void TearDown() => this.server.Stop();
+
+    [TestMethod]
+    public async Task Insert_ShouldRetryUntilSuccess_GivenRetryableStatus()
+    {
+        var client = new Client(this.server.Url!, new ClientOptions { Retry = RetryOnce });
+        this.MockPostReturns503ThenCreated("[{\"id\":1,\"name\":\"walk the dog\"}]");
+
+        var response = await client.Table<Todo>().Insert(new Todo { Name = "walk the dog" });
+
+        response.Models.Should().ContainSingle().Which.Name.Should().Be("walk the dog");
+    }
+
+    [TestMethod]
+    public async Task Insert_ShouldResendBody_GivenARetriedAttempt()
+    {
+        var client = new Client(this.server.Url!, new ClientOptions { Retry = RetryOnce });
+        this.MockPostReturns503ThenCreated("[]");
+
+        await client.Table<Todo>().Insert(new Todo { Name = "walk the dog" });
+
+        var requests = this.server.LogEntries.ToList();
+        requests.Should().HaveCount(2);
+        requests[1].RequestMessage!.Body!.Should().Contain("walk the dog", "the retried attempt must resend the body");
+    }
+
+    [TestMethod]
+    public async Task Insert_ShouldNotRetry_GivenDefaultOptions()
+    {
+        var client = new Client(this.server.Url!, new ClientOptions());
+        this.server.Given(Request.Create().WithPath("/todos").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(503));
+
+        var act = () => client.Table<Todo>().Insert(new Todo { Name = "walk the dog" });
+
+        await act.Should().ThrowAsync<PostgrestException>();
+        this.server.LogEntries.Should().ContainSingle("the default policy does not retry");
+    }
+
+    private void MockPostReturns503ThenCreated(string body)
+    {
+        this.server.Given(Request.Create().WithPath("/todos").UsingPost())
+            .InScenario("retry").WillSetStateTo("retried")
+            .RespondWith(Response.Create().WithStatusCode(503));
+        this.server.Given(Request.Create().WithPath("/todos").UsingPost())
+            .InScenario("retry").WhenStateIs("retried")
+            .RespondWith(Response.Create().WithStatusCode(201).WithHeader("Content-Type", "application/json").WithBody(body));
+    }
+}

--- a/packages/Postgrest/Postgrest/ClientOptions.cs
+++ b/packages/Postgrest/Postgrest/ClientOptions.cs
@@ -1,31 +1,34 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Globalization;
+using Supabase.Core.Http;
 #pragma warning disable CS1591
-namespace Supabase.Postgrest
+namespace Supabase.Postgrest;
+
+
+/// <summary>
+/// Options that can be passed to the Client configuration
+/// </summary>
+public class ClientOptions
 {
+    public string Schema { get; set; } = "public";
 
-	/// <summary>
-	/// Options that can be passed to the Client configuration
-	/// </summary>
-	public class ClientOptions
-	{
-		public string Schema { get; set; } = "public";
+    public readonly DateTimeStyles DateTimeStyles = DateTimeStyles.AdjustToUniversal;
 
-		public readonly DateTimeStyles DateTimeStyles = DateTimeStyles.AdjustToUniversal;
+    public const string DATE_TIME_FORMAT = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFK";
 
-		public const string DATE_TIME_FORMAT = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFK";
+    /// <summary>
+    /// When true, enum properties without their own `[JsonConverter]` attribute are serialized by
+    /// name (e.g. "OffDisplay") instead of their underlying integer value. Enable this if your enum
+    /// properties map to native PostgreSQL `enum` columns. Leave disabled (default) if any of your
+    /// enum properties map to `integer`/`smallint` columns, since enabling this would send a string
+    /// to a numeric column and PostgREST would reject the request.
+    /// </summary>
+    public bool SerializeEnumsAsStrings { get; set; }
 
-		/// <summary>
-		/// When true, enum properties without their own `[JsonConverter]` attribute are serialized by
-		/// name (e.g. "OffDisplay") instead of their underlying integer value. Enable this if your enum
-		/// properties map to native PostgreSQL `enum` columns. Leave disabled (default) if any of your
-		/// enum properties map to `integer`/`smallint` columns, since enabling this would send a string
-		/// to a numeric column and PostgREST would reject the request.
-		/// </summary>
-		public bool SerializeEnumsAsStrings { get; set; }
+    public Dictionary<string, string> Headers { get; set; } = new Dictionary<string, string>();
 
-		public Dictionary<string, string> Headers { get; set; } = new Dictionary<string, string>();
+    public Dictionary<string, string> QueryParams { get; set; } = new Dictionary<string, string>();
 
-		public Dictionary<string, string> QueryParams { get; set; } = new Dictionary<string, string>();
-	}
+    /// <summary>Retry policy applied to each request. Default (<see cref="RetryOptions.MaxRetries"/> 0) sends once, unretried.</summary>
+    public RetryOptions Retry { get; set; } = new RetryOptions();
 }

--- a/packages/Postgrest/Postgrest/Helpers.cs
+++ b/packages/Postgrest/Postgrest/Helpers.cs
@@ -12,6 +12,7 @@ using System.Web;
 using Supabase.Core;
 using Supabase.Core.Diagnostics;
 using Supabase.Core.Extensions;
+using Supabase.Core.Http;
 using Supabase.Postgrest.Exceptions;
 using Supabase.Postgrest.Models;
 using Supabase.Postgrest.Responses;
@@ -93,7 +94,7 @@ internal static class Helpers
 
         builder.Query = query.ToString();
 
-        using var requestMessage = new HttpRequestMessage(method, builder.Uri);
+        string? body = null;
 
         if (data != null && method != HttpMethod.Get)
         {
@@ -101,16 +102,28 @@ internal static class Helpers
 
             if (!string.IsNullOrWhiteSpace(stringContent) && HasValues(stringContent))
             {
-                requestMessage.Content = new StringContent(stringContent, Encoding.UTF8, "application/json");
+                body = stringContent;
             }
         }
 
-        if (headers != null)
+        HttpRequestMessage CreateRequest()
         {
-            foreach (var kvp in headers)
+            var requestMessage = new HttpRequestMessage(method, builder.Uri);
+
+            if (body != null)
             {
-                requestMessage.Headers.TryAddWithoutValidation(kvp.Key, kvp.Value);
+                requestMessage.Content = new StringContent(body, Encoding.UTF8, "application/json");
             }
+
+            if (headers != null)
+            {
+                foreach (var kvp in headers)
+                {
+                    requestMessage.Headers.TryAddWithoutValidation(kvp.Key, kvp.Value);
+                }
+            }
+
+            return requestMessage;
         }
 
         using var activity = PostgrestInstrumentation.StartHttpActivity(method, builder.Uri, operation);
@@ -120,7 +133,7 @@ internal static class Helpers
 
         try
         {
-            using var response = await Client.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+            using var response = await RetryExecutor.SendAsync(Client, CreateRequest, clientOptions.Retry, cancellationToken).ConfigureAwait(false);
             statusCode = (int) response.StatusCode;
             activity.SetHttpResponseTags(statusCode.Value);
 

--- a/packages/Postgrest/Postgrest/PublicAPI.Unshipped.txt
+++ b/packages/Postgrest/Postgrest/PublicAPI.Unshipped.txt
@@ -10,6 +10,8 @@ override Supabase.Postgrest.Converters.PostgrestStringEnumConverter.CreateConver
 static Supabase.Postgrest.Client.SerializerSettings(Supabase.Postgrest.ClientOptions? options = null) -> System.Text.Json.JsonSerializerOptions!
 Supabase.Postgrest.Attributes.ColumnAttribute.ColumnAttribute(string? columnName = null, System.Text.Json.Serialization.JsonIgnoreCondition nullValueHandling = System.Text.Json.Serialization.JsonIgnoreCondition.Never, bool ignoreOnInsert = false, bool ignoreOnUpdate = false) -> void
 Supabase.Postgrest.Attributes.ColumnAttribute.NullValueHandling.get -> System.Text.Json.Serialization.JsonIgnoreCondition
+Supabase.Postgrest.ClientOptions.Retry.get -> Supabase.Core.Http.RetryOptions!
+Supabase.Postgrest.ClientOptions.Retry.set -> void
 Supabase.Postgrest.Converters.DateTimeListConverter
 Supabase.Postgrest.Converters.DateTimeListConverter.DateTimeListConverter() -> void
 Supabase.Postgrest.Converters.PostgrestStringEnumConverter

--- a/packages/Supabase/Supabase.Tests/StatelessClientTests.cs
+++ b/packages/Supabase/Supabase.Tests/StatelessClientTests.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Core.Http;
 using static Supabase.Gotrue.Constants;
 using static Supabase.StatelessClient;
 
@@ -68,6 +70,14 @@ public class StatelessClientTests
         options.Headers["X-Custom"] = "custom-value";
         GetRestOptions("my-key", options).Headers.Should().ContainKey("X-Custom")
             .WhoseValue.Should().Be("custom-value", "developer headers must flow through to the child clients");
+    }
+
+    [TestMethod]
+    public void GetRestOptions_ShouldForwardPostgrestRetry_GivenCustomRetryOptions()
+    {
+        var retry = new RetryOptions { MaxRetries = 2, BaseDelay = TimeSpan.FromMilliseconds(5) };
+        var restOptions = GetRestOptions("my-key", new Supabase.SupabaseOptions { PostgrestRetry = retry });
+        restOptions.Retry.Should().BeSameAs(retry, "the retry policy must reach the Postgrest client");
     }
 
     [TestMethod]

--- a/packages/Supabase/Supabase.Tests/SupabaseOptionsTests.cs
+++ b/packages/Supabase/Supabase.Tests/SupabaseOptionsTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Supabase;
 
 namespace Supabase.Tests;
 
@@ -26,6 +25,7 @@ public class SupabaseOptionsTests
             options.RealtimeUrlFormat.Should().Be("{0}/realtime/v1");
             options.StorageUrlFormat.Should().Be("{0}/storage/v1");
             options.FunctionsUrlFormat.Should().Be("{0}/functions/v1");
+            options.PostgrestRetry.MaxRetries.Should().Be(0);
         }
     }
 }

--- a/packages/Supabase/Supabase/Client.cs
+++ b/packages/Supabase/Supabase/Client.cs
@@ -1,278 +1,277 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Supabase.Postgrest.Interfaces;
-using Supabase.Postgrest.Models;
-using Supabase.Postgrest.Responses;
 using Supabase.Core;
 using Supabase.Functions.Interfaces;
 using Supabase.Gotrue;
 using Supabase.Gotrue.Interfaces;
 using Supabase.Interfaces;
+using Supabase.Postgrest.Interfaces;
+using Supabase.Postgrest.Models;
+using Supabase.Postgrest.Responses;
 using Supabase.Realtime;
 using Supabase.Realtime.Interfaces;
 using Supabase.Storage;
 using Supabase.Storage.Interfaces;
 using static Supabase.Gotrue.Constants;
 
-namespace Supabase
+namespace Supabase;
+
+/// <summary>
+/// A class representing the Supabase Client, coordinating between all child APIs
+/// </summary>
+public class Client : ISupabaseClient<User, Session, RealtimeSocket, RealtimeChannel, Bucket, FileObject>
 {
     /// <summary>
-    /// A class representing the Supabase Client, coordinating between all child APIs
+    /// Supabase Auth allows you to create and manage user sessions for access to data that is secured by access policies.
     /// </summary>
-    public class Client : ISupabaseClient<User, Session, RealtimeSocket, RealtimeChannel, Bucket, FileObject>
+    public IGotrueClient<User, Session> Auth
     {
-        /// <summary>
-        /// Supabase Auth allows you to create and manage user sessions for access to data that is secured by access policies.
-        /// </summary>
-        public IGotrueClient<User, Session> Auth
+        get => this.auth;
+        set
         {
-            get => this.auth;
-            set
-            {
-                // Remove existing internal state listener (if applicable)
-                this.auth.RemoveStateChangedListener(this.Auth_StateChanged);
-                this.auth = value;
-                this.auth.AddStateChangedListener(this.Auth_StateChanged);
-            }
-        }
-
-        private IGotrueClient<User, Session> auth;
-
-        /// <summary>
-        /// Returns a Stateless Gotrue Admin client given a service_key JWT. This should really only be accessed from a
-        /// server environment where a private service_key would remain secure.
-        /// </summary>
-        /// <param name="serviceKey"></param>
-        /// <returns></returns>
-        public IGotrueAdminClient<User> AdminAuth(string serviceKey) =>
-            new AdminClient(serviceKey, new Gotrue.ClientOptions
-            {
-                Url = string.Format(this.options.AuthUrlFormat, this.supabaseUrl),
-                AutoRefreshToken = this.options.AutoRefreshToken
-            })
-            {
-                GetHeaders = this.GetAuthHeaders,
-            };
-
-        /// <summary>
-        /// Supabase Realtime allows for realtime feedback on database changes.
-        /// </summary>
-        public IRealtimeClient<RealtimeSocket, RealtimeChannel> Realtime
-        {
-            get => this.realtime;
-            set
-            {
-                // Disconnect from previous RealtimeSocket (if applicable)
-                this.realtime.Disconnect();
-                this.realtime = value;
-            }
-        }
-
-        private IRealtimeClient<RealtimeSocket, RealtimeChannel> realtime;
-
-        /// <summary>
-        /// Supabase Edge functions allow you to deploy and invoke edge functions.
-        /// </summary>
-        public IFunctionsClient Functions
-        {
-            get => this.functions;
-            set => this.functions = value;
-        }
-
-        private IFunctionsClient functions;
-
-        /// <summary>
-        /// Supabase Postgrest allows for strongly typed REST interactions with your database.
-        /// </summary>
-        public IPostgrestClient Postgrest
-        {
-            get => this.postgrest;
-            set => this.postgrest = value;
-        }
-
-        private IPostgrestClient postgrest;
-
-        /// <summary>
-        /// Supabase Storage allows you to manage user-generated content, such as photos or videos.
-        /// </summary>
-        public IStorageClient<Bucket, FileObject> Storage
-        {
-            get => this.storage;
-            set => this.storage = value;
-        }
-
-        private IStorageClient<Bucket, FileObject> storage;
-
-        private readonly string? supabaseUrl;
-        private readonly string? supabaseKey;
-        private readonly SupabaseOptions options;
-
-        /// <summary>
-        /// Constructor supplied for dependency injection support.
-        /// </summary>
-        /// <param name="auth"></param>
-        /// <param name="realtime"></param>
-        /// <param name="functions"></param>
-        /// <param name="postgrest"></param>
-        /// <param name="storage"></param>
-        /// <param name="options"></param>
-        public Client(IGotrueClient<User, Session> auth, IRealtimeClient<RealtimeSocket, RealtimeChannel> realtime,
-            IFunctionsClient functions, IPostgrestClient postgrest, IStorageClient<Bucket, FileObject> storage,
-            SupabaseOptions options)
-        {
-            this.auth = auth;
-            this.realtime = realtime;
-            this.functions = functions;
-            this.postgrest = postgrest;
-            this.storage = storage;
-            this.options = options;
-            this.realtime.Options.PostgrestClient = this.postgrest;
-        }
-
-        /// <summary>
-        /// Creates a new Supabase Client.
-        /// </summary>
-        /// <param name="supabaseUrl"></param>
-        /// <param name="supabaseKey"></param>
-        /// <param name="options"></param>
-        public Client(string supabaseUrl, string? supabaseKey, SupabaseOptions? options = null)
-        {
-            this.supabaseUrl = supabaseUrl;
-            this.supabaseKey = supabaseKey;
-            this.options = options ?? new SupabaseOptions();
-
-            var authUrl = string.Format(this.options.AuthUrlFormat, supabaseUrl);
-            var restUrl = string.Format(this.options.RestUrlFormat, supabaseUrl);
-            var realtimeUrl = string.Format(this.options.RealtimeUrlFormat, supabaseUrl).Replace("http", "ws");
-            var storageUrl = string.Format(this.options.StorageUrlFormat, supabaseUrl);
-            var schema = this.options.Schema;
-
-            // See: https://github.com/supabase/supabase-js/blob/09065a65f171bc28a9fd7b831af2c24e5f1a380b/src/SupabaseClient.ts#L77-L83
-            var isPlatform = new Regex(@"(supabase\.co)|(supabase\.in)").Match(supabaseUrl);
-
-            string? functionsUrl;
-            if (isPlatform.Success)
-            {
-                var parts = supabaseUrl.Split('.');
-                functionsUrl = $"{parts[0]}.functions.{parts[1]}.{parts[2]}";
-            }
-            else
-            {
-                functionsUrl = string.Format(this.options.FunctionsUrlFormat, supabaseUrl);
-            }
-
-            // Init Auth
-            var gotrueOptions = new Gotrue.ClientOptions
-            {
-                Url = authUrl,
-                AutoRefreshToken = this.options.AutoRefreshToken
-            };
-            this.auth = new Gotrue.Client(gotrueOptions);
-            this.auth.SetPersistence(this.options.SessionHandler);
+            // Remove existing internal state listener (if applicable)
+            this.auth.RemoveStateChangedListener(this.Auth_StateChanged);
+            this.auth = value;
             this.auth.AddStateChangedListener(this.Auth_StateChanged);
-            this.auth.GetHeaders = this.GetAuthHeaders;
-            this.postgrest = new Postgrest.Client(restUrl, new Postgrest.ClientOptions { Schema = schema });
-            this.postgrest.GetHeaders = this.GetAuthHeaders;
-
-            // Init Realtime
-
-            var realtimeOptions = new Realtime.ClientOptions
-            {
-                Parameters = { ApiKey = this.supabaseKey },
-                PostgrestClient = this.postgrest
-            };
-            this.realtime = new Realtime.Client(realtimeUrl, realtimeOptions);
-            this.realtime.GetHeaders = this.GetAuthHeaders;
-            this.functions = new Functions.Client(functionsUrl);
-            this.functions.GetHeaders = this.GetAuthHeaders;
-            this.storage = new Storage.Client(storageUrl, this.options.StorageClientOptions);
-            this.storage.GetHeaders = this.GetAuthHeaders;
         }
-
-
-        /// <summary>
-        /// Attempts to retrieve the session from Gotrue (set in <see cref="SupabaseOptions"/>) and connects to realtime (if `options.AutoConnectRealtime` is set)
-        /// </summary>
-        public async Task<ISupabaseClient<User, Session, RealtimeSocket, RealtimeChannel, Bucket, FileObject>>
-            InitializeAsync()
-        {
-            await this.Auth.RetrieveSessionAsync();
-
-            if (this.options.AutoConnectRealtime)
-                await this.Realtime.ConnectAsync();
-
-            return this;
-        }
-
-        private void Auth_StateChanged(object sender, AuthState e)
-        {
-            switch (e)
-            {
-                // Pass new Auth down to Realtime
-                // Ref: https://github.com/supabase-community/supabase-csharp/issues/12
-                case AuthState.SignedIn:
-                case AuthState.TokenRefreshed:
-                case AuthState.UserUpdated:
-                    if (this.Auth.CurrentSession?.AccessToken != null)
-                        this.Realtime.SetAuth(this.Auth.CurrentSession.AccessToken);
-                    break;
-                // Remove Realtime Subscriptions on Auth Sign-out.
-                case AuthState.SignedOut:
-                    this.Realtime.Subscriptions.Values?.ToList().ForEach(subscription => subscription.Unsubscribe());
-                    break;
-                case AuthState.PasswordRecovery:
-                case AuthState.Shutdown: break;
-                case AuthState.MfaChallengeVerified:
-                default: throw new ArgumentOutOfRangeException(nameof(e), e, null);
-            }
-        }
-
-        /// <summary>
-        /// Gets the Postgrest client to prepare for a query.
-        /// </summary>
-        /// <typeparam name="TModel"></typeparam>
-        /// <returns></returns>
-        public ISupabaseTable<TModel, RealtimeChannel> From<TModel>() where TModel : BaseModel, new() =>
-            new SupabaseTable<TModel>(this.Postgrest, this.Realtime);
-
-        /// <inheritdoc />
-        public Task<BaseResponse> Rpc(string procedureName, object? parameters) => this.postgrest.Rpc(procedureName, parameters);
-
-        /// <inheritdoc />
-        public Task<TModeledResponse?> Rpc<TModeledResponse>(string procedureName, object? parameters) => this.postgrest.Rpc<TModeledResponse>(procedureName, parameters);
-
-        /// <summary>
-        /// Produces a dictionary of Headers that will be supplied to child clients.
-        ///</summary>
-        internal Dictionary<string, string> GetAuthHeaders()
-        {
-            var headers = CaseInsensitiveHeaders();
-            headers["X-Client-Info"] = Util.GetAssemblyVersion(typeof(Client));
-
-            if (this.supabaseKey != null)
-                headers["apiKey"] = this.supabaseKey;
-
-            // In Regard To: https://github.com/supabase/supabase-csharp/issues/5
-            if (this.options.Headers.TryGetValue("Authorization", out var header))
-            {
-                headers["Authorization"] = header;
-            }
-            else
-            {
-                var bearer = this.Auth.CurrentSession?.AccessToken ?? this.supabaseKey;
-                headers["Authorization"] = $"Bearer {bearer}";
-            }
-
-            // Add supplied headers from `ClientOptions` by developer
-            foreach (var kvp in this.options.Headers)
-                headers[kvp.Key] = kvp.Value;
-
-            return headers;
-        }
-
-        private static Dictionary<string, string> CaseInsensitiveHeaders() => new(StringComparer.OrdinalIgnoreCase);
     }
+
+    private IGotrueClient<User, Session> auth;
+
+    /// <summary>
+    /// Returns a Stateless Gotrue Admin client given a service_key JWT. This should really only be accessed from a
+    /// server environment where a private service_key would remain secure.
+    /// </summary>
+    /// <param name="serviceKey"></param>
+    /// <returns></returns>
+    public IGotrueAdminClient<User> AdminAuth(string serviceKey) =>
+        new AdminClient(serviceKey, new Gotrue.ClientOptions
+        {
+            Url = string.Format(this.options.AuthUrlFormat, this.supabaseUrl),
+            AutoRefreshToken = this.options.AutoRefreshToken
+        })
+        {
+            GetHeaders = this.GetAuthHeaders,
+        };
+
+    /// <summary>
+    /// Supabase Realtime allows for realtime feedback on database changes.
+    /// </summary>
+    public IRealtimeClient<RealtimeSocket, RealtimeChannel> Realtime
+    {
+        get => this.realtime;
+        set
+        {
+            // Disconnect from previous RealtimeSocket (if applicable)
+            this.realtime.Disconnect();
+            this.realtime = value;
+        }
+    }
+
+    private IRealtimeClient<RealtimeSocket, RealtimeChannel> realtime;
+
+    /// <summary>
+    /// Supabase Edge functions allow you to deploy and invoke edge functions.
+    /// </summary>
+    public IFunctionsClient Functions
+    {
+        get => this.functions;
+        set => this.functions = value;
+    }
+
+    private IFunctionsClient functions;
+
+    /// <summary>
+    /// Supabase Postgrest allows for strongly typed REST interactions with your database.
+    /// </summary>
+    public IPostgrestClient Postgrest
+    {
+        get => this.postgrest;
+        set => this.postgrest = value;
+    }
+
+    private IPostgrestClient postgrest;
+
+    /// <summary>
+    /// Supabase Storage allows you to manage user-generated content, such as photos or videos.
+    /// </summary>
+    public IStorageClient<Bucket, FileObject> Storage
+    {
+        get => this.storage;
+        set => this.storage = value;
+    }
+
+    private IStorageClient<Bucket, FileObject> storage;
+
+    private readonly string? supabaseUrl;
+    private readonly string? supabaseKey;
+    private readonly SupabaseOptions options;
+
+    /// <summary>
+    /// Constructor supplied for dependency injection support.
+    /// </summary>
+    /// <param name="auth"></param>
+    /// <param name="realtime"></param>
+    /// <param name="functions"></param>
+    /// <param name="postgrest"></param>
+    /// <param name="storage"></param>
+    /// <param name="options"></param>
+    public Client(IGotrueClient<User, Session> auth, IRealtimeClient<RealtimeSocket, RealtimeChannel> realtime,
+        IFunctionsClient functions, IPostgrestClient postgrest, IStorageClient<Bucket, FileObject> storage,
+        SupabaseOptions options)
+    {
+        this.auth = auth;
+        this.realtime = realtime;
+        this.functions = functions;
+        this.postgrest = postgrest;
+        this.storage = storage;
+        this.options = options;
+        this.realtime.Options.PostgrestClient = this.postgrest;
+    }
+
+    /// <summary>
+    /// Creates a new Supabase Client.
+    /// </summary>
+    /// <param name="supabaseUrl"></param>
+    /// <param name="supabaseKey"></param>
+    /// <param name="options"></param>
+    public Client(string supabaseUrl, string? supabaseKey, SupabaseOptions? options = null)
+    {
+        this.supabaseUrl = supabaseUrl;
+        this.supabaseKey = supabaseKey;
+        this.options = options ?? new SupabaseOptions();
+
+        var authUrl = string.Format(this.options.AuthUrlFormat, supabaseUrl);
+        var restUrl = string.Format(this.options.RestUrlFormat, supabaseUrl);
+        var realtimeUrl = string.Format(this.options.RealtimeUrlFormat, supabaseUrl).Replace("http", "ws");
+        var storageUrl = string.Format(this.options.StorageUrlFormat, supabaseUrl);
+        var schema = this.options.Schema;
+
+        // See: https://github.com/supabase/supabase-js/blob/09065a65f171bc28a9fd7b831af2c24e5f1a380b/src/SupabaseClient.ts#L77-L83
+        var isPlatform = new Regex(@"(supabase\.co)|(supabase\.in)").Match(supabaseUrl);
+
+        string? functionsUrl;
+        if (isPlatform.Success)
+        {
+            var parts = supabaseUrl.Split('.');
+            functionsUrl = $"{parts[0]}.functions.{parts[1]}.{parts[2]}";
+        }
+        else
+        {
+            functionsUrl = string.Format(this.options.FunctionsUrlFormat, supabaseUrl);
+        }
+
+        // Init Auth
+        var gotrueOptions = new Gotrue.ClientOptions
+        {
+            Url = authUrl,
+            AutoRefreshToken = this.options.AutoRefreshToken
+        };
+        this.auth = new Gotrue.Client(gotrueOptions);
+        this.auth.SetPersistence(this.options.SessionHandler);
+        this.auth.AddStateChangedListener(this.Auth_StateChanged);
+        this.auth.GetHeaders = this.GetAuthHeaders;
+        this.postgrest = new Postgrest.Client(restUrl, new Postgrest.ClientOptions { Schema = schema, Retry = this.options.PostgrestRetry });
+        this.postgrest.GetHeaders = this.GetAuthHeaders;
+
+        // Init Realtime
+
+        var realtimeOptions = new Realtime.ClientOptions
+        {
+            Parameters = { ApiKey = this.supabaseKey },
+            PostgrestClient = this.postgrest
+        };
+        this.realtime = new Realtime.Client(realtimeUrl, realtimeOptions);
+        this.realtime.GetHeaders = this.GetAuthHeaders;
+        this.functions = new Functions.Client(functionsUrl);
+        this.functions.GetHeaders = this.GetAuthHeaders;
+        this.storage = new Storage.Client(storageUrl, this.options.StorageClientOptions);
+        this.storage.GetHeaders = this.GetAuthHeaders;
+    }
+
+
+    /// <summary>
+    /// Attempts to retrieve the session from Gotrue (set in <see cref="SupabaseOptions"/>) and connects to realtime (if `options.AutoConnectRealtime` is set)
+    /// </summary>
+    public async Task<ISupabaseClient<User, Session, RealtimeSocket, RealtimeChannel, Bucket, FileObject>>
+        InitializeAsync()
+    {
+        await this.Auth.RetrieveSessionAsync();
+
+        if (this.options.AutoConnectRealtime)
+            await this.Realtime.ConnectAsync();
+
+        return this;
+    }
+
+    private void Auth_StateChanged(object sender, AuthState e)
+    {
+        switch (e)
+        {
+            // Pass new Auth down to Realtime
+            // Ref: https://github.com/supabase-community/supabase-csharp/issues/12
+            case AuthState.SignedIn:
+            case AuthState.TokenRefreshed:
+            case AuthState.UserUpdated:
+                if (this.Auth.CurrentSession?.AccessToken != null)
+                    this.Realtime.SetAuth(this.Auth.CurrentSession.AccessToken);
+                break;
+            // Remove Realtime Subscriptions on Auth Sign-out.
+            case AuthState.SignedOut:
+                this.Realtime.Subscriptions.Values?.ToList().ForEach(subscription => subscription.Unsubscribe());
+                break;
+            case AuthState.PasswordRecovery:
+            case AuthState.Shutdown: break;
+            case AuthState.MfaChallengeVerified:
+            default: throw new ArgumentOutOfRangeException(nameof(e), e, null);
+        }
+    }
+
+    /// <summary>
+    /// Gets the Postgrest client to prepare for a query.
+    /// </summary>
+    /// <typeparam name="TModel"></typeparam>
+    /// <returns></returns>
+    public ISupabaseTable<TModel, RealtimeChannel> From<TModel>() where TModel : BaseModel, new() =>
+        new SupabaseTable<TModel>(this.Postgrest, this.Realtime);
+
+    /// <inheritdoc />
+    public Task<BaseResponse> Rpc(string procedureName, object? parameters) => this.postgrest.Rpc(procedureName, parameters);
+
+    /// <inheritdoc />
+    public Task<TModeledResponse?> Rpc<TModeledResponse>(string procedureName, object? parameters) => this.postgrest.Rpc<TModeledResponse>(procedureName, parameters);
+
+    /// <summary>
+    /// Produces a dictionary of Headers that will be supplied to child clients.
+    ///</summary>
+    internal Dictionary<string, string> GetAuthHeaders()
+    {
+        var headers = CaseInsensitiveHeaders();
+        headers["X-Client-Info"] = Util.GetAssemblyVersion(typeof(Client));
+
+        if (this.supabaseKey != null)
+            headers["apiKey"] = this.supabaseKey;
+
+        // In Regard To: https://github.com/supabase/supabase-csharp/issues/5
+        if (this.options.Headers.TryGetValue("Authorization", out var header))
+        {
+            headers["Authorization"] = header;
+        }
+        else
+        {
+            var bearer = this.Auth.CurrentSession?.AccessToken ?? this.supabaseKey;
+            headers["Authorization"] = $"Bearer {bearer}";
+        }
+
+        // Add supplied headers from `ClientOptions` by developer
+        foreach (var kvp in this.options.Headers)
+            headers[kvp.Key] = kvp.Value;
+
+        return headers;
+    }
+
+    private static Dictionary<string, string> CaseInsensitiveHeaders() => new(StringComparer.OrdinalIgnoreCase);
 }

--- a/packages/Supabase/Supabase/PublicAPI.Unshipped.txt
+++ b/packages/Supabase/Supabase/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Supabase.SupabaseOptions.PostgrestRetry.get -> Supabase.Core.Http.RetryOptions!
+Supabase.SupabaseOptions.PostgrestRetry.set -> void

--- a/packages/Supabase/Supabase/StatelessClient.cs
+++ b/packages/Supabase/Supabase/StatelessClient.cs
@@ -1,170 +1,170 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Supabase.Postgrest.Models;
-using Supabase.Postgrest.Responses;
 using Supabase.Core;
 using Supabase.Extensions;
 using Supabase.Functions.Interfaces;
+using Supabase.Postgrest.Models;
+using Supabase.Postgrest.Responses;
 using Supabase.Storage;
 using Supabase.Storage.Interfaces;
 
-namespace Supabase
+namespace Supabase;
+
+/// <summary>
+/// A Static class representing a Supabase Client.
+/// </summary>
+public static class StatelessClient
 {
     /// <summary>
-    /// A Static class representing a Supabase Client.
+    /// Returns an instance of <see cref="Gotrue.ClientOptions"/> given a provided url and key.
     /// </summary>
-    public static class StatelessClient
+    /// <param name="supabaseUrl"></param>
+    /// <param name="supabaseKey"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public static Gotrue.ClientOptions GetAuthOptions(string supabaseUrl, string? supabaseKey = null, SupabaseOptions? options = null)
     {
-        /// <summary>
-        /// Returns an instance of <see cref="Gotrue.ClientOptions"/> given a provided url and key.
-        /// </summary>
-        /// <param name="supabaseUrl"></param>
-        /// <param name="supabaseKey"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        public static Gotrue.ClientOptions GetAuthOptions(string supabaseUrl, string? supabaseKey = null, SupabaseOptions? options = null)
+        options ??= new SupabaseOptions();
+
+        var headers = GetAuthHeaders(supabaseKey, options).MergeLeft(options.Headers);
+
+        return new Gotrue.ClientOptions
         {
-            options ??= new SupabaseOptions();
+            Url = string.Format(options.AuthUrlFormat, supabaseUrl),
+            Headers = headers
+        };
+    }
 
-            var headers = GetAuthHeaders(supabaseKey, options).MergeLeft(options.Headers);
+    /// <summary>
+    /// Returns an instance of <see cref="Postgrest.ClientOptions"/> for a given supabase key.
+    /// </summary>
+    /// <param name="supabaseKey"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public static Postgrest.ClientOptions GetRestOptions(string? supabaseKey = null, SupabaseOptions? options = null)
+    {
+        options ??= new SupabaseOptions();
 
-            return new Gotrue.ClientOptions
-            {
-                Url = string.Format(options.AuthUrlFormat, supabaseUrl),
-                Headers = headers
-            };
+        var headers = GetAuthHeaders(supabaseKey, options).MergeLeft(options.Headers);
+
+        return new Postgrest.ClientOptions
+        {
+            Schema = options.Schema,
+            Headers = headers,
+            Retry = options.PostgrestRetry
+        };
+    }
+
+    /// <summary>
+    /// Supabase Storage allows you to manage user-generated content, such as photos or videos.
+    /// </summary>
+    /// <param name="supabaseUrl"></param>
+    /// <param name="supabaseKey"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public static IStorageClient<Bucket, FileObject> Storage(string supabaseUrl, string? supabaseKey = null, SupabaseOptions? options = null)
+    {
+        options ??= new SupabaseOptions();
+
+        var headers = GetAuthHeaders(supabaseKey, options).MergeLeft(options.Headers);
+
+        return new Storage.Client(string.Format(options.StorageUrlFormat, supabaseUrl), headers);
+    }
+
+    /// <summary>
+    /// Supabase Edge functions allow you to deploy and invoke edge functions.
+    /// </summary>
+    /// <param name="supabaseUrl"></param>
+    /// <param name="supabaseKey"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public static IFunctionsClient Functions(string supabaseUrl, string supabaseKey, SupabaseOptions? options = null)
+    {
+        options ??= new SupabaseOptions();
+
+        // See: https://github.com/supabase/supabase-js/blob/09065a65f171bc28a9fd7b831af2c24e5f1a380b/src/SupabaseClient.ts#L77-L83
+        var isPlatform = new Regex(@"/(supabase\.co)|(supabase\.in)/").Match(supabaseUrl);
+
+        string functionsUrl;
+        if (isPlatform.Success)
+        {
+            var parts = supabaseUrl.Split('.');
+            functionsUrl = $"{parts[0]}.functions.{parts[1]}.{parts[2]}";
+        }
+        else
+        {
+            functionsUrl = string.Format(options.FunctionsUrlFormat, supabaseUrl);
         }
 
-        /// <summary>
-        /// Returns an instance of <see cref="Postgrest.ClientOptions"/> for a given supabase key.
-        /// </summary>
-        /// <param name="supabaseKey"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        public static Postgrest.ClientOptions GetRestOptions(string? supabaseKey = null, SupabaseOptions? options = null)
+        var headers = GetAuthHeaders(supabaseKey, options).MergeLeft(options.Headers);
+        var client = new Functions.Client(functionsUrl);
+        client.GetHeaders = () => headers;
+
+        return client;
+    }
+
+    /// <summary>
+    /// Gets the Postgrest client to prepare for a query.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static SupabaseTable<T> From<T>(string supabaseUrl, string supabaseKey, SupabaseOptions? options = null) where T : BaseModel, new()
+    {
+        options ??= new SupabaseOptions();
+
+        var restUrl = string.Format(options.RestUrlFormat, supabaseUrl);
+        var realtimeUrl = string.Format(options.RealtimeUrlFormat, supabaseUrl).Replace("http", "ws");
+
+        var restOptions = GetRestOptions(supabaseKey, options);
+        restOptions.Headers.MergeLeft(options.Headers);
+
+        var realtimeOptions = new Realtime.ClientOptions { Parameters = { ApiKey = supabaseKey } };
+
+        var postgrestClient = new Postgrest.Client(restUrl, restOptions);
+        var realtimeClient = new Realtime.Client(realtimeUrl, realtimeOptions);
+
+        return new SupabaseTable<T>(postgrestClient, realtimeClient, options.Schema);
+    }
+
+    /// <summary>
+    /// Runs a remote procedure.
+    /// </summary>
+    /// <param name="supabaseUrl"></param>
+    /// <param name="supabaseKey"></param>
+    /// <param name="procedureName"></param>
+    /// <param name="parameters"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public static Task<BaseResponse> Rpc(string supabaseUrl, string supabaseKey, string procedureName, Dictionary<string, object> parameters, SupabaseOptions? options = null)
+    {
+        options ??= new SupabaseOptions();
+
+        return new Postgrest.Client(string.Format(options.RestUrlFormat, supabaseUrl), GetRestOptions(supabaseKey, options)).Rpc(procedureName, parameters);
+    }
+
+
+    internal static Dictionary<string, string> GetAuthHeaders(string? supabaseKey, SupabaseOptions options)
+    {
+        var headers = new Dictionary<string, string>();
+
+        headers["X-Client-Info"] = Util.GetAssemblyVersion(typeof(Client));
+
+        if (supabaseKey != null)
         {
-            options ??= new SupabaseOptions();
-
-            var headers = GetAuthHeaders(supabaseKey, options).MergeLeft(options.Headers);
-
-            return new Postgrest.ClientOptions
-            {
-                Schema = options.Schema,
-                Headers = headers
-            };
+            headers["apiKey"] = supabaseKey;
         }
 
-        /// <summary>
-        /// Supabase Storage allows you to manage user-generated content, such as photos or videos.
-        /// </summary>
-        /// <param name="supabaseUrl"></param>
-        /// <param name="supabaseKey"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        public static IStorageClient<Bucket, FileObject> Storage(string supabaseUrl, string? supabaseKey = null, SupabaseOptions? options = null)
+        // In Regard To: https://github.com/supabase/supabase-csharp/issues/5
+        if (options.Headers.TryGetValue("Authorization", out var header))
         {
-            options ??= new SupabaseOptions();
-
-            var headers = GetAuthHeaders(supabaseKey, options).MergeLeft(options.Headers);
-
-            return new Storage.Client(string.Format(options.StorageUrlFormat, supabaseUrl), headers);
+            headers["Authorization"] = header;
+        }
+        else
+        {
+            headers["Authorization"] = $"Bearer {supabaseKey}";
         }
 
-        /// <summary>
-        /// Supabase Edge functions allow you to deploy and invoke edge functions.
-        /// </summary>
-        /// <param name="supabaseUrl"></param>
-        /// <param name="supabaseKey"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        public static IFunctionsClient Functions(string supabaseUrl, string supabaseKey, SupabaseOptions? options = null)
-        {
-            options ??= new SupabaseOptions();
-
-            // See: https://github.com/supabase/supabase-js/blob/09065a65f171bc28a9fd7b831af2c24e5f1a380b/src/SupabaseClient.ts#L77-L83
-            var isPlatform = new Regex(@"/(supabase\.co)|(supabase\.in)/").Match(supabaseUrl);
-
-            string functionsUrl;
-            if (isPlatform.Success)
-            {
-                var parts = supabaseUrl.Split('.');
-                functionsUrl = $"{parts[0]}.functions.{parts[1]}.{parts[2]}";
-            }
-            else
-            {
-                functionsUrl = string.Format(options.FunctionsUrlFormat, supabaseUrl);
-            }
-
-            var headers = GetAuthHeaders(supabaseKey, options).MergeLeft(options.Headers);
-            var client = new Functions.Client(functionsUrl);
-            client.GetHeaders = () => headers;
-
-            return client;
-        }
-
-        /// <summary>
-        /// Gets the Postgrest client to prepare for a query.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static SupabaseTable<T> From<T>(string supabaseUrl, string supabaseKey, SupabaseOptions? options = null) where T : BaseModel, new()
-        {
-            options ??= new SupabaseOptions();
-
-            var restUrl = string.Format(options.RestUrlFormat, supabaseUrl);
-            var realtimeUrl = string.Format(options.RealtimeUrlFormat, supabaseUrl).Replace("http", "ws");
-
-            var restOptions = GetRestOptions(supabaseKey, options);
-            restOptions.Headers.MergeLeft(options.Headers);
-
-            var realtimeOptions = new Realtime.ClientOptions { Parameters = { ApiKey = supabaseKey } };
-
-            var postgrestClient = new Postgrest.Client(restUrl, restOptions);
-            var realtimeClient = new Realtime.Client(realtimeUrl, realtimeOptions);
-
-            return new SupabaseTable<T>(postgrestClient, realtimeClient, options.Schema);
-        }
-
-        /// <summary>
-        /// Runs a remote procedure.
-        /// </summary>
-        /// <param name="supabaseUrl"></param>
-        /// <param name="supabaseKey"></param>
-        /// <param name="procedureName"></param>
-        /// <param name="parameters"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        public static Task<BaseResponse> Rpc(string supabaseUrl, string supabaseKey, string procedureName, Dictionary<string, object> parameters, SupabaseOptions? options = null)
-        {
-            options ??= new SupabaseOptions();
-
-            return new Postgrest.Client(string.Format(options.RestUrlFormat, supabaseUrl), GetRestOptions(supabaseKey, options)).Rpc(procedureName, parameters);
-        }
-
-
-        internal static Dictionary<string, string> GetAuthHeaders(string? supabaseKey, SupabaseOptions options)
-        {
-            var headers = new Dictionary<string, string>();
-
-            headers["X-Client-Info"] = Util.GetAssemblyVersion(typeof(Client));
-
-            if (supabaseKey != null)
-            {
-                headers["apiKey"] = supabaseKey;
-            }
-
-            // In Regard To: https://github.com/supabase/supabase-csharp/issues/5
-            if (options.Headers.TryGetValue("Authorization", out var header))
-            {
-                headers["Authorization"] = header;
-            }
-            else
-            {
-                headers["Authorization"] = $"Bearer {supabaseKey}";
-            }
-
-            return headers;
-        }
+        return headers;
     }
 }

--- a/packages/Supabase/Supabase/SupabaseOptions.cs
+++ b/packages/Supabase/Supabase/SupabaseOptions.cs
@@ -1,69 +1,73 @@
-﻿using Supabase.Gotrue;
 using System.Collections.Generic;
+using Supabase.Gotrue;
 using Supabase.Gotrue.Interfaces;
 
-namespace Supabase
+namespace Supabase;
+
+/// <summary>
+/// Options available for Supabase Client Configuration
+/// </summary>
+public class SupabaseOptions
 {
     /// <summary>
-    /// Options available for Supabase Client Configuration
+    /// Schema to be used in Postgres / Realtime
     /// </summary>
-    public class SupabaseOptions
-    {
-        /// <summary>
-        /// Schema to be used in Postgres / Realtime
-        /// </summary>
-        public string Schema = "public";
+    public string Schema = "public";
 
-        /// <summary>
-        /// Should the Client automatically handle refreshing the User's Token?
-        /// </summary>
-        public bool AutoRefreshToken { get; set; } = true;
+    /// <summary>
+    /// Should the Client automatically handle refreshing the User's Token?
+    /// </summary>
+    public bool AutoRefreshToken { get; set; } = true;
 
-        /// <summary>
-        /// Should the Client automatically connect to Realtime?
-        /// </summary>
-        public bool AutoConnectRealtime { get; set; }
+    /// <summary>
+    /// Should the Client automatically connect to Realtime?
+    /// </summary>
+    public bool AutoConnectRealtime { get; set; }
 
-        /// <summary>
-        /// Functions passed to Gotrue that handle sessions. 
-        /// 
-        /// **By default these do nothing for persistence.**
-        /// </summary>
-        public IGotrueSessionPersistence<Session> SessionHandler { get; set; } = new DefaultSupabaseSessionHandler();
+    /// <summary>
+    /// Functions passed to Gotrue that handle sessions. 
+    /// 
+    /// **By default these do nothing for persistence.**
+    /// </summary>
+    public IGotrueSessionPersistence<Session> SessionHandler { get; set; } = new DefaultSupabaseSessionHandler();
 
-        /// <summary>
-        /// Allows developer to specify options that will be passed to all child Supabase clients.
-        /// </summary>
-        public Dictionary<string, string> Headers = new();
+    /// <summary>
+    /// Allows developer to specify options that will be passed to all child Supabase clients.
+    /// </summary>
+    public Dictionary<string, string> Headers = new();
 
-        /// <summary>
-        /// Specifies Options passed to the StorageClient.
-        /// </summary>
-        public Storage.ClientOptions StorageClientOptions { get; set; } = new();
+    /// <summary>
+    /// Specifies Options passed to the StorageClient.
+    /// </summary>
+    public Storage.ClientOptions StorageClientOptions { get; set; } = new();
 
-        /// <summary>
-        /// The Supabase Auth Url Format
-        /// </summary>
-        public string AuthUrlFormat { get; set; } = "{0}/auth/v1";
-        
-        /// <summary>
-        /// The Supabase Postgrest Url Format
-        /// </summary>
-        public string RestUrlFormat { get; set; } = "{0}/rest/v1";
-        
-        /// <summary>
-        /// The Supabase Realtime Url Format
-        /// </summary>
-        public string RealtimeUrlFormat { get; set; } = "{0}/realtime/v1";
-        
-        /// <summary>
-        /// The Supabase Storage Url Format
-        /// </summary>
-        public string StorageUrlFormat { get; set; } = "{0}/storage/v1";
+    /// <summary>
+    /// Retry policy passed to the Postgrest client. Defaults to no retries.
+    /// </summary>
+    public Supabase.Core.Http.RetryOptions PostgrestRetry { get; set; } = new();
 
-        /// <summary>
-        /// The Supabase Functions Url Format
-        /// </summary>
-        public string FunctionsUrlFormat { get; set; } = "{0}/functions/v1";
-    }
+    /// <summary>
+    /// The Supabase Auth Url Format
+    /// </summary>
+    public string AuthUrlFormat { get; set; } = "{0}/auth/v1";
+
+    /// <summary>
+    /// The Supabase Postgrest Url Format
+    /// </summary>
+    public string RestUrlFormat { get; set; } = "{0}/rest/v1";
+
+    /// <summary>
+    /// The Supabase Realtime Url Format
+    /// </summary>
+    public string RealtimeUrlFormat { get; set; } = "{0}/realtime/v1";
+
+    /// <summary>
+    /// The Supabase Storage Url Format
+    /// </summary>
+    public string StorageUrlFormat { get; set; } = "{0}/storage/v1";
+
+    /// <summary>
+    /// The Supabase Functions Url Format
+    /// </summary>
+    public string FunctionsUrlFormat { get; set; } = "{0}/functions/v1";
 }


### PR DESCRIPTION
adds a retry option for transient postgrest errors, parity with supabase-js db.retry (closes #297)

- new ClientOptions.Retry using the shared core RetryOptions, default off so existing behaviour is unchanged (js has retry on by default, our sdk never retried, so opt-in matches the functions and gotrue shape from #370/#371 instead of a bare boolean)
- exposed on the umbrella client as SupabaseOptions.PostgrestRetry
- wiremock tests cover retry until success, resent body on the retried attempt and no retry by default
- touched files ran through dotnet format

quality gate passes for both packages