### PR TITLE
fix(gotrue): ask the server to skip its redirect when linking an identity

### DIFF
--- a/packages/Gotrue/Gotrue.Tests/Authentication/IdentityLinkApprovalTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Authentication/IdentityLinkApprovalTests.cs
@@ -25,4 +25,18 @@ public class IdentityLinkApprovalTests : RequestApprovalFixture
             new LinkIdentityWithIdTokenOptions(Constants.Provider.Google, "id-token-value"));
         await this.Verify(this.EmittedRequestBody).UseDirectory("Data");
     }
+
+    /// <summary>
+    ///     Regression (#378): the provider-link GET must ask the server to skip its redirect so the
+    ///     browser is not sent to the provider without the Authorization header ("No API key found
+    ///     in request"). auth-js' linkIdentity sets skip_http_redirect for exactly this reason.
+    /// </summary>
+    [TestMethod]
+    public async Task LinkIdentityRequest_ShouldCarrySkipHttpRedirect_GivenAnyProvider()
+    {
+        await this.Api.LinkIdentity("user-jwt", Constants.Provider.GitHub, new SignInOptions());
+        this.EmittedRequest
+            .WithPath("/user/identities/authorize")
+            .WithQueryParam("skip_http_redirect", "true");
+    }
 }

--- a/packages/Gotrue/Gotrue.Tests/Support/RequestApprovalFixture.cs
+++ b/packages/Gotrue/Gotrue.Tests/Support/RequestApprovalFixture.cs
@@ -42,4 +42,9 @@ public abstract class RequestApprovalFixture : VerifyBase
     ///     own method so the snapshot file lands next to the test (domain-first layout), not beside this fixture.
     /// </summary>
     protected string EmittedRequestBody => this.server.VerifySingleReceivedRequest().RawBody;
+
+    /// <summary>
+    ///     The single request the SDK emitted, for assertions over path/query/headers.
+    /// </summary>
+    protected ReceivedRequest EmittedRequest => this.server.VerifySingleReceivedRequest();
 }

--- a/packages/Gotrue/Gotrue/Api.cs
+++ b/packages/Gotrue/Gotrue/Api.cs
@@ -588,7 +588,15 @@ public class Api : IGotrueApi<User, Session>
     public async Task<ProviderAuthState> LinkIdentity(string token, Provider provider, SignInOptions options)
     {
         var state = Helpers.GetUrlForProvider($"{this.Url}/user/identities/authorize", provider, options);
-        await this.MakeRequestAsync(HttpMethod.Get, state.Uri.ToString(), null, this.CreateAuthedRequestHeaders(token));
+
+        // Without this the server responds with a redirect to the provider's
+        // sign-in page, which the browser follows without the Authorization
+        // header and the request then fails with "No API key found in
+        // request" (#378). Skipping the redirect returns the provider URL in
+        // the response body for the client to navigate to, matching
+        // auth-js' linkIdentity behavior.
+        var uri = Helpers.AddQueryParams(state.Uri.ToString(), new Dictionary<string, string> { { "skip_http_redirect", "true" } });
+        await this.MakeRequestAsync(HttpMethod.Get, uri.ToString(), null, this.CreateAuthedRequestHeaders(token));
         return state;
     }
 


### PR DESCRIPTION
Fixes #378.

## Root cause

`Api.LinkIdentity` issues its `GET /user/identities/authorize` **without** `skip_http_redirect`. The server responds with a redirect to the provider's sign-in page; the browser follows the redirect **without** the `Authorization` header, and the request then fails with:

```
{"message":"No API key found in request","hint":"No `apikey` request header or url param was found."}
```

auth-js' `linkIdentity` sets `skip_http_redirect` for exactly this reason — with it, the server returns the provider URL in the response body for the client to navigate to, instead of redirecting (the same shape this SDK's own `signInWithSSO` already relies on, see its `skip_http_redirect` body parameter).

## Fix

Add `skip_http_redirect=true` to the query on the LinkIdentity request, matching auth-js. The returned `ProviderAuthState` (whose URI the caller navigates to) is unchanged.

## Test

Added `LinkIdentityRequest_ShouldCarrySkipHttpRedirect_GivenAnyProvider` to the wire-shape approval tests (`IdentityLinkApprovalTests`): asserts the emitted request hits `/user/identities/authorize` with `skip_http_redirect=true`, using the fixture's new `EmittedRequest` accessor alongside the existing `EmittedRequestBody`.

**Note:** no .NET SDK on this machine — the change follows the file's existing patterns exactly (`Helpers.AddQueryParams` is already used the same way elsewhere) and CI runs the suite.
