### PR TITLE
feat(storage): expose service error code

### DIFF
--- a/packages/Storage/README.md
+++ b/packages/Storage/README.md
@@ -77,6 +77,12 @@ var publicUrl = bucket.GetPublicUrl("me.png", null);
 var signedUrl = await bucket.CreateSignedUrl("me.png", 3600);
 ```
 
+## Error handling
+
+Storage failures throw a `SupabaseStorageException`. Use `Code` for the exact service error (for
+example, `NoSuchKey`) and `Reason` for the broader classification. `Code` is `null` when the response
+does not include one. See the [Storage error code reference](https://supabase.com/docs/guides/storage/debugging/error-codes).
+
 ## Observability (OpenTelemetry)
 
 The client emits traces and metrics through `System.Diagnostics`, so you can wire them into

--- a/packages/Storage/Storage.Tests/Errors/ErrorResponseTests.cs
+++ b/packages/Storage/Storage.Tests/Errors/ErrorResponseTests.cs
@@ -19,14 +19,28 @@ public class ErrorResponseTests
         ErrorResponse.TryParse("Upload failed: gateway error").Should().BeNull();
 
     [TestMethod]
-    public void TryParse_ShouldReadStatusAndMessage_GivenJsonBody()
+    public void TryParse_ShouldReadStatusMessageAndCode_GivenJsonBody()
     {
-        var parsed = ErrorResponse.TryParse("{\"statusCode\":404,\"message\":\"Not found\"}");
+        var parsed = ErrorResponse.TryParse(
+            "{\"statusCode\":\"404\",\"error\":\"not_found\",\"code\":\"NoSuchKey\",\"message\":\"Object not found\"}");
         using (new AssertionScope())
         {
             parsed.Should().NotBeNull();
             parsed!.StatusCode.Should().Be(404);
-            parsed.Message.Should().Be("Not found");
+            parsed.Message.Should().Be("Object not found");
+            parsed.Code.Should().Be("NoSuchKey");
+        }
+    }
+
+    [TestMethod]
+    public void TryParse_ShouldLeaveCodeNull_GivenCodeMissing()
+    {
+        var parsed = ErrorResponse.TryParse(
+            "{\"statusCode\":\"404\",\"error\":\"not_found\",\"message\":\"Object not found\"}");
+        using (new AssertionScope())
+        {
+            parsed.Should().NotBeNull();
+            parsed!.Code.Should().BeNull();
         }
     }
 }

--- a/packages/Storage/Storage.Tests/Files/StorageFileApiContractTests.cs
+++ b/packages/Storage/Storage.Tests/Files/StorageFileApiContractTests.cs
@@ -293,6 +293,21 @@ public class StorageFileApiContractTests
     }
 
     [TestMethod]
+    public async Task Download_ShouldSurfaceServiceCode_GivenJsonError()
+    {
+        const string body =
+            "{\"statusCode\":\"404\",\"error\":\"not_found\",\"code\":\"NoSuchKey\",\"message\":\"Object not found\"}";
+        this.Respond($"/storage/v1/object/{Bucket}/missing.bin", "GET", 404, body);
+        var act = () => this.client.From(Bucket).Download("missing.bin", (EventHandler<float>?) null);
+        var exception = (await act.Should().ThrowAsync<SupabaseStorageException>()).Which;
+        using (new AssertionScope())
+        {
+            exception.Code.Should().Be("NoSuchKey");
+            exception.Reason.Should().Be(FailureHint.Reason.NotFound);
+        }
+    }
+
+    [TestMethod]
     public async Task Download_ShouldSendTheCacheNonceInTheQuery_GivenACacheNonce()
     {
         this.server.Given(Request.Create().WithPath($"/storage/v1/object/{Bucket}/a.bin").UsingGet())

--- a/packages/Storage/Storage/Exceptions/SupabaseStorageException.cs
+++ b/packages/Storage/Storage/Exceptions/SupabaseStorageException.cs
@@ -1,24 +1,25 @@
-﻿using System;
+using System;
 using System.Net.Http;
 
-namespace Supabase.Storage.Exceptions
+namespace Supabase.Storage.Exceptions;
+
+public class SupabaseStorageException : Exception
 {
-    public class SupabaseStorageException : Exception
-    {
-        public SupabaseStorageException(string? message) : base(message) { }
-        public SupabaseStorageException(string? message, Exception? innerException) : base(message, innerException) { }
+    public SupabaseStorageException(string? message) : base(message) { }
+    public SupabaseStorageException(string? message, Exception? innerException) : base(message, innerException) { }
 
-        public HttpResponseMessage? Response { get; internal set; }
+    public HttpResponseMessage? Response { get; internal set; }
 
-        public string? Content { get; internal set; }
+    public string? Content { get; internal set; }
 
-        public int StatusCode { get; internal set; }
+    public int StatusCode { get; internal set; }
 
-        public FailureHint.Reason Reason { get; private set; }
+    /// <summary>
+    /// Gets the error code returned by the Storage service, if available.
+    /// </summary>
+    public string? Code { get; internal set; }
 
-        public void AddReason()
-        {
-            Reason = FailureHint.DetectReason(this);
-        }
-    }
+    public FailureHint.Reason Reason { get; private set; }
+
+    public void AddReason() => this.Reason = FailureHint.DetectReason(this);
 }

--- a/packages/Storage/Storage/Extensions/HttpClientProgress.cs
+++ b/packages/Storage/Storage/Extensions/HttpClientProgress.cs
@@ -74,6 +74,7 @@ internal static class HttpClientProgress
                         Content = content,
                         Response = response,
                         StatusCode = resolvedStatus,
+                        Code = errorResponse?.Code,
                     };
 
                     e.AddReason();
@@ -231,6 +232,7 @@ internal static class HttpClientProgress
                     Content = httpContent,
                     Response = response,
                     StatusCode = resolvedStatus,
+                    Code = errorResponse?.Code,
                 };
 
                 e.AddReason();
@@ -431,6 +433,7 @@ internal static class HttpClientProgress
             Content = httpContent,
             Response = response,
             StatusCode = errorResponse?.StatusCode ?? (int) response.StatusCode,
+            Code = errorResponse?.Code,
         };
         error.AddReason();
 
@@ -442,11 +445,13 @@ internal static class HttpClientProgress
     )
     {
         var httpContent = await response.OriginHttpResponse.Content.ReadAsStringAsync();
+        var errorResponse = ErrorResponse.TryParse(httpContent);
         var error = new SupabaseStorageException(httpContent)
         {
             Content = httpContent,
             Response = response.OriginHttpResponse,
             StatusCode = (int) response.OriginHttpResponse.StatusCode,
+            Code = errorResponse?.Code,
         };
         error.AddReason();
 

--- a/packages/Storage/Storage/Helpers.cs
+++ b/packages/Storage/Storage/Helpers.cs
@@ -133,7 +133,8 @@ internal static class Helpers
                 {
                     Content = content,
                     Response = response,
-                    StatusCode = resolvedStatus
+                    StatusCode = resolvedStatus,
+                    Code = errorResponse?.Code,
                 };
 
                 e.AddReason();
@@ -166,6 +167,12 @@ public class ErrorResponse
 {
     [JsonPropertyName("statusCode")]
     public int StatusCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the error code returned by the Storage service.
+    /// </summary>
+    [JsonPropertyName("code")]
+    public string? Code { get; set; }
 
     [JsonPropertyName("message")]
     public string? Message { get; set; }

--- a/packages/Storage/Storage/PublicAPI.Unshipped.txt
+++ b/packages/Storage/Storage/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Supabase.Storage.ErrorResponse.Code.get -> string?
+Supabase.Storage.ErrorResponse.Code.set -> void
+Supabase.Storage.Exceptions.SupabaseStorageException.Code.get -> string?


### PR DESCRIPTION
Exposes the storage service error code through SupabaseStorageException.Code. Code remains null when it is not provided. Existing Reason behavior and TUS error messages remain unchanged.

Closes #299