### PR TITLE
fix(storage): percent-encode object key in cdn purge urls

### DIFF
--- a/packages/Storage/Storage.Tests/Buckets/StorageBucketApiContractTests.cs
+++ b/packages/Storage/Storage.Tests/Buckets/StorageBucketApiContractTests.cs
@@ -165,6 +165,15 @@ public class StorageBucketApiContractTests
         this.SingleRequest().Query.Should().Contain(pair => pair.Key == "transformations" && pair.Value.Contains("true"));
     }
 
+    [TestMethod]
+    public async Task PurgeBucketCache_ShouldEncodeDelimiters_GivenABucketIdWithUrlDelimiters()
+    {
+        this.Respond("/storage/v1/cdn/*", "DELETE", 200, "{\"message\":\"success\"}");
+        await this.client.PurgeBucketCache("my?bucket");
+        this.SingleRequest().AbsoluteUrl.Should().EndWith("/storage/v1/cdn/my%3Fbucket",
+            "a raw '?' in the id would start a query string and purge the wrong bucket");
+    }
+
     private void Respond(string path, string method, int statusCode, string body) =>
         this.server.Given(Request.Create().WithPath(path).UsingMethod(method))
             .RespondWith(Response.Create().WithStatusCode(statusCode)

--- a/packages/Storage/Storage.Tests/Files/StorageFileApiContractTests.cs
+++ b/packages/Storage/Storage.Tests/Files/StorageFileApiContractTests.cs
@@ -352,6 +352,15 @@ public class StorageFileApiContractTests
     }
 
     [TestMethod]
+    public async Task PurgeCache_ShouldEncodeDelimiters_GivenAKeyWithUrlDelimiters()
+    {
+        this.Respond("/storage/v1/cdn/*", "DELETE", 200, "{\"message\":\"success\"}");
+        await this.client.From(Bucket).PurgeCache("folder/a?b#c.png");
+        this.SingleRequest().AbsoluteUrl.Should().EndWith($"/storage/v1/cdn/{Bucket}/folder/a%3Fb%23c.png",
+            "an unescaped '?' or '#' truncates the key into a query string or fragment");
+    }
+
+    [TestMethod]
     public async Task Upload_ShouldSurfaceStorageException_GivenNonJsonError()
     {
         const string body = "<html><head><title>413 Request Entity Too Large</title></head></html>";

--- a/packages/Storage/Storage/Helpers.cs
+++ b/packages/Storage/Storage/Helpers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -168,6 +169,13 @@ internal static class Helpers
             StorageInstrumentation.RecordRequest(method, builder.Uri, statusCode, errorType, startTimestamp);
         }
     }
+
+    /// <summary>
+    /// Percent-encodes each segment of a storage path so a <c>?</c> or <c>#</c> in a key can't start
+    /// a query string or fragment, while <c>/</c> stays literal as the separator.
+    /// </summary>
+    internal static string EncodePath(string path) =>
+        string.Join("/", path.Split('/').Select(Uri.EscapeDataString));
 }
 
 public class GenericResponse

--- a/packages/Storage/Storage/StorageBucketApi.cs
+++ b/packages/Storage/Storage/StorageBucketApi.cs
@@ -168,7 +168,7 @@ public class StorageBucketApi : IStorageBucketApi<Bucket>
         CancellationToken cancellationToken = default
     )
     {
-        var url = options.ToPurgeUrl($"{this.Url}/cdn/{id}");
+        var url = options.ToPurgeUrl($"{this.Url}/cdn/{Helpers.EncodePath(id)}");
         return Helpers.MakeRequestAsync<GenericResponse>(this.requestClient, this.Options.Retry, HttpMethod.Delete, url, null, this.Headers, cancellationToken);
     }
 }

--- a/packages/Storage/Storage/StorageFileApi.cs
+++ b/packages/Storage/Storage/StorageFileApi.cs
@@ -811,7 +811,7 @@ public class StorageFileApi : IStorageFileApi<FileObject>
         CancellationToken cancellationToken = default
     )
     {
-        var url = options.ToPurgeUrl($"{this.Url}/cdn/{this.GetFinalPath(path)}");
+        var url = options.ToPurgeUrl($"{this.Url}/cdn/{Helpers.EncodePath(this.GetFinalPath(path))}");
         return Helpers.MakeRequestAsync<GenericResponse>(this.requestClient, this.Options.Retry, HttpMethod.Delete, url, null, this.Headers, cancellationToken);
     }
 


### PR DESCRIPTION
closes #298

a ? or # in an object key was read as the start of a query string or fragment, so the purge hit the wrong path:

```
purgeCache("folder/a?b#c.png")

before  DELETE /cdn/bucket/folder/a?b
after   DELETE /cdn/bucket/folder/a%3Fb%23c.png
```

this percent-encodes each path segment, same as supabase/supabase-js#2545.

upstream only did this for the two purge urls, not for sign/render/object, so i kept it to the same two.

i didn't put the encoding in `GetFinalPath` because the upload methods return that value back to the caller as the key.
