### PR TITLE
feat(realtime): throw exception when try to update postgres change

### DIFF
--- a/packages/Realtime/Realtime.Tests/PostgresChanges/PostgresChangesDeliveryTests.cs
+++ b/packages/Realtime/Realtime.Tests/PostgresChanges/PostgresChangesDeliveryTests.cs
@@ -56,7 +56,7 @@ public class PostgresChangesDeliveryTests
     public async Task OnPostgresChange_ShouldThrowError_GivenOnChangeAfterSubscribe()
     {
         var tsc = new TaskCompletionSource<bool>();
-        var channel = socketClient.Channel("example");
+        var channel = this.socketClient.Channel("example");
         channel.OnPostgresChange((_, changes) =>
         {
             var model = changes.Model<Todo>();
@@ -77,8 +77,7 @@ public class PostgresChangesDeliveryTests
     [TestMethod]
     public async Task OnPostgresChange_ShouldThrowError_GivenRegisterChangesAfterSubscribe()
     {
-        var tsc = new TaskCompletionSource<bool>();
-        var channel = socketClient.Channel("example");
+        var channel = this.socketClient.Channel("example");
         await channel.Subscribe();
 
         var act = () => channel.RegisterPostgresChangesOptions(new PostgresChangesOptions("example"));

--- a/packages/Realtime/Realtime.Tests/PostgresChanges/PostgresChangesDeliveryTests.cs
+++ b/packages/Realtime/Realtime.Tests/PostgresChanges/PostgresChangesDeliveryTests.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Realtime.Tests.Models;
 using Supabase.Postgrest.Interfaces;
 using Supabase.Realtime;
+using Supabase.Realtime.Exceptions;
 using Supabase.Realtime.Interfaces;
 using Supabase.Realtime.PostgresChanges;
 using static Supabase.Realtime.Constants;
@@ -49,6 +50,39 @@ public class PostgresChangesDeliveryTests
         await channel.Subscribe();
         await restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client Models a response? ✅" });
         Assert.IsTrue(await tsc.Task);
+    }
+
+    [TestMethod]
+    public async Task OnPostgresChange_ShouldThrowError_GivenOnChangeAfterSubscribe()
+    {
+        var tsc = new TaskCompletionSource<bool>();
+        var channel = socketClient.Channel("example");
+        channel.OnPostgresChange((_, changes) =>
+        {
+            var model = changes.Model<Todo>();
+            tsc.SetResult(model != null);
+        }, ListenType.Inserts, new PostgresChangesFilter { Table = "*" });
+
+        await channel.Subscribe();
+
+        var act = () => channel.OnPostgresChange((_, changes) =>
+        {
+            var model = changes.Model<Todo>();
+            tsc.SetResult(model != null);
+        }, ListenType.Inserts, new PostgresChangesFilter { Table = "*" });
+
+        Assert.Throws<RealtimeException>(act);
+    }
+
+    [TestMethod]
+    public async Task OnPostgresChange_ShouldThrowError_GivenRegisterChangesAfterSubscribe()
+    {
+        var tsc = new TaskCompletionSource<bool>();
+        var channel = socketClient.Channel("example");
+        await channel.Subscribe();
+
+        var act = () => channel.RegisterPostgresChangesOptions(new PostgresChangesOptions("example"));
+        Assert.Throws<RealtimeException>(act);
     }
 
     [TestMethod]

--- a/packages/Realtime/Realtime.Tests/PostgresChanges/PostgresChangesDeliveryTests.cs
+++ b/packages/Realtime/Realtime.Tests/PostgresChanges/PostgresChangesDeliveryTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -29,26 +28,26 @@ public class PostgresChangesDeliveryTests
     [TestInitialize]
     public async Task InitializeTest()
     {
-        restClient = Helpers.RestClient();
-        socketClient = Helpers.SocketClient();
-        await socketClient.ConnectAsync();
+        this.restClient = Helpers.RestClient();
+        this.socketClient = Helpers.SocketClient();
+        await this.socketClient.ConnectAsync();
     }
 
     [TestCleanup]
-    public void CleanupTest() => socketClient.Disconnect();
+    public void CleanupTest() => this.socketClient.Disconnect();
 
     [TestMethod]
     public async Task OnPostgresChange_ShouldModelPayload()
     {
         var tsc = new TaskCompletionSource<bool>();
-        var channel = socketClient.Channel("example");
+        var channel = this.socketClient.Channel("example");
         channel.OnPostgresChange((_, changes) =>
         {
             var model = changes.Model<Todo>();
             tsc.SetResult(model != null);
         }, ListenType.Inserts, new PostgresChangesFilter { Table = "*" });
         await channel.Subscribe();
-        await restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client Models a response? ✅" });
+        await this.restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client Models a response? ✅" });
         Assert.IsTrue(await tsc.Task);
     }
 
@@ -88,11 +87,11 @@ public class PostgresChangesDeliveryTests
     public async Task OnPostgresChange_ShouldReceiveInsert()
     {
         var tsc = new TaskCompletionSource<bool>();
-        var channel = socketClient.Channel("realtime", "public", "todos");
+        var channel = this.socketClient.Channel("realtime", "public", "todos");
         channel.OnPostgresChange((_, _) => tsc.SetResult(true), ListenType.Inserts,
             new PostgresChangesFilter { Table = "todos" });
         await channel.Subscribe();
-        await restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives insert callback? ✅" });
+        await this.restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives insert callback? ✅" });
         Assert.IsTrue(await tsc.Task);
     }
 
@@ -100,7 +99,7 @@ public class PostgresChangesDeliveryTests
     public async Task OnPostgresChange_ShouldReceiveFilteredInsert()
     {
         var tsc = new TaskCompletionSource<bool>();
-        var channel = socketClient.Channel("realtime", "public", "todos");
+        var channel = this.socketClient.Channel("realtime", "public", "todos");
         channel.OnPostgresChange((_, changes) =>
         {
             Assert.AreEqual("Client receives filtered insert callback? ✅", changes.Model<Todo>()?.Details);
@@ -108,8 +107,8 @@ public class PostgresChangesDeliveryTests
         }, ListenType.Inserts,
             new PostgresChangesFilter { Table = "todos", Filter = "details=eq.Client receives filtered insert callback? ✅" });
         await channel.Subscribe();
-        await restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives insert callback? ✅" });
-        await restClient.Table<Todo>().Insert(new Todo { UserId = 2, Details = "Client receives filtered insert callback? ✅" });
+        await this.restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives insert callback? ✅" });
+        await this.restClient.Table<Todo>().Insert(new Todo { UserId = 2, Details = "Client receives filtered insert callback? ✅" });
         Assert.IsTrue(await tsc.Task);
     }
 
@@ -117,14 +116,14 @@ public class PostgresChangesDeliveryTests
     public async Task OnPostgresChange_ShouldReceiveUpdateAndFilteredInsert()
     {
         var tsc = new TaskCompletionSource<bool>();
-        var response = await restClient.Table<Todo>()
+        var response = await this.restClient.Table<Todo>()
             .Insert(new Todo { UserId = 1, Details = "Client receives insert callback? ✅" });
-        await restClient.Table<Todo>()
+        await this.restClient.Table<Todo>()
             .Insert(new Todo { UserId = 2, Details = "Client receives filtered insert callback? ✅" });
         var model = response.Models.First();
         var oldDetails = model.Details;
         var newDetails = $"I'm an updated item ✏️ - {DateTime.Now}";
-        var channel = socketClient.Channel("realtime", "public", "todos");
+        var channel = this.socketClient.Channel("realtime", "public", "todos");
         channel.OnPostgresChange((_, changes) =>
         {
             Assert.AreEqual(oldDetails, changes.OldModel<Todo>()?.Details);
@@ -144,7 +143,7 @@ public class PostgresChangesDeliveryTests
             tsc.SetResult(true);
         }, ListenType.Inserts, new PostgresChangesFilter { Table = "todos", Filter = $"details=eq.{filter}" });
         await channel.Subscribe();
-        await restClient.Table<Todo>().Set(x => x.Details!, newDetails).Match(model).Update();
+        await this.restClient.Table<Todo>().Set(x => x.Details!, newDetails).Match(model).Update();
         Assert.IsTrue(await tsc.Task);
     }
 
@@ -152,12 +151,12 @@ public class PostgresChangesDeliveryTests
     public async Task OnPostgresChange_ShouldReceiveUpdate()
     {
         var tsc = new TaskCompletionSource<bool>();
-        var response = await restClient.Table<Todo>()
+        var response = await this.restClient.Table<Todo>()
             .Insert(new Todo { UserId = 1, Details = "Client receives insert callback? ✅" });
         var model = response.Models.First();
         var oldDetails = model.Details;
         var newDetails = $"I'm an updated item ✏️ - {DateTime.Now}";
-        var channel = socketClient.Channel("realtime", "public", "todos");
+        var channel = this.socketClient.Channel("realtime", "public", "todos");
         channel.OnPostgresChange((_, changes) =>
         {
             Assert.AreEqual(oldDetails, changes.OldModel<Todo>()?.Details);
@@ -171,7 +170,7 @@ public class PostgresChangesDeliveryTests
             tsc.SetResult(true);
         }, ListenType.Updates, new PostgresChangesFilter { Table = "todos" });
         await channel.Subscribe();
-        await restClient.Table<Todo>().Set(x => x.Details!, newDetails).Match(model).Update();
+        await this.restClient.Table<Todo>().Set(x => x.Details!, newDetails).Match(model).Update();
         Assert.IsTrue(await tsc.Task);
     }
 
@@ -179,13 +178,13 @@ public class PostgresChangesDeliveryTests
     public async Task OnPostgresChange_ShouldReceiveDelete()
     {
         var tsc = new TaskCompletionSource<bool>();
-        var channel = socketClient.Channel("realtime", "public", "todos");
+        var channel = this.socketClient.Channel("realtime", "public", "todos");
         channel.OnPostgresChange((_, _) => tsc.SetResult(true), ListenType.Deletes,
             new PostgresChangesFilter { Table = "todos" });
         await channel.Subscribe();
-        var result = await restClient.Table<Todo>().Get();
+        var result = await this.restClient.Table<Todo>().Get();
         var model = result.Models.Last();
-        await restClient.Table<Todo>().Match(model).Delete();
+        await this.restClient.Table<Todo>().Match(model).Delete();
         Assert.IsTrue(await tsc.Task);
     }
 
@@ -193,10 +192,10 @@ public class PostgresChangesDeliveryTests
     public async Task OnPostgresChange_ShouldReceiveFilteredDelete()
     {
         var tsc = new TaskCompletionSource<bool>();
-        var channel = socketClient.Channel("realtime", "public", "todos");
-        var todo1 = await restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives callbacks 1? ✅" });
-        var todo2 = await restClient.Table<Todo>().Insert(new Todo { UserId = 2, Details = "Client receives callbacks 2? ✅" });
-        await restClient.Table<Todo>().Insert(new Todo { UserId = 3, Details = "Client receives callbacks 3? ✅" });
+        var channel = this.socketClient.Channel("realtime", "public", "todos");
+        var todo1 = await this.restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives callbacks 1? ✅" });
+        var todo2 = await this.restClient.Table<Todo>().Insert(new Todo { UserId = 2, Details = "Client receives callbacks 2? ✅" });
+        await this.restClient.Table<Todo>().Insert(new Todo { UserId = 3, Details = "Client receives callbacks 3? ✅" });
         channel.OnPostgresChange((_, removed) =>
         {
             var result = removed.OldModel<Todo>();
@@ -206,8 +205,8 @@ public class PostgresChangesDeliveryTests
         }, ListenType.Deletes,
             new PostgresChangesFilter { Table = "todos", Filter = $"details=eq.{todo1.Model?.Details}" });
         await channel.Subscribe();
-        await restClient.Table<Todo>().Match(todo1.Models.First()).Delete();
-        await restClient.Table<Todo>().Match(todo2.Models.First()).Delete();
+        await this.restClient.Table<Todo>().Match(todo1.Models.First()).Delete();
+        await this.restClient.Table<Todo>().Match(todo2.Models.First()).Delete();
         Assert.IsTrue(await tsc.Task);
     }
 
@@ -217,7 +216,7 @@ public class PostgresChangesDeliveryTests
         var insertTsc = new TaskCompletionSource<bool>();
         var updateTsc = new TaskCompletionSource<bool>();
         var deleteTsc = new TaskCompletionSource<bool>();
-        var channel = socketClient.Channel("realtime", "public", "todos");
+        var channel = this.socketClient.Channel("realtime", "public", "todos");
         channel.OnPostgresChange((_, changes) =>
         {
             switch (changes.Payload?.Data?.Type)
@@ -228,10 +227,10 @@ public class PostgresChangesDeliveryTests
             }
         }, ListenType.All, new PostgresChangesFilter { Table = "todos" });
         await channel.Subscribe();
-        var inserted = await restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives wildcard callbacks? ✅" });
+        var inserted = await this.restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives wildcard callbacks? ✅" });
         var newModel = inserted.Models.First();
-        await restClient.Table<Todo>().Set(x => x.Details!, "And edits.").Match(newModel).Update();
-        await restClient.Table<Todo>().Match(newModel).Delete();
+        await this.restClient.Table<Todo>().Set(x => x.Details!, "And edits.").Match(newModel).Update();
+        await this.restClient.Table<Todo>().Match(newModel).Delete();
         await Task.WhenAll(insertTsc.Task, updateTsc.Task, deleteTsc.Task);
         Assert.IsTrue(insertTsc.Task.Result);
         Assert.IsTrue(updateTsc.Task.Result);
@@ -246,7 +245,7 @@ public class PostgresChangesDeliveryTests
         var insertTask3 = new TaskCompletionSource<bool>();
         const string filter1 = "Client receives callbacks 1? ✅";
         const string filter2 = "Client receives callbacks 2? ✅";
-        var channel = socketClient.Channel("realtime", "public", "todos");
+        var channel = this.socketClient.Channel("realtime", "public", "todos");
         var count = 0;
         channel.OnPostgresChange((_, _) =>
         {
@@ -260,9 +259,9 @@ public class PostgresChangesDeliveryTests
             insertTask3.SetResult(added.Model<Todo>()?.Details == filter2), ListenType.Inserts,
             new PostgresChangesFilter { Table = "todos", Filter = $"details=eq.{filter2}" });
         await channel.Subscribe();
-        await restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives wildcard callbacks? ✅" });
-        await restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = filter1 });
-        await restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = filter2 });
+        await this.restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "Client receives wildcard callbacks? ✅" });
+        await this.restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = filter1 });
+        await this.restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = filter2 });
         await Task.WhenAll(insertTask1.Task, insertTask2.Task, insertTask3.Task);
         Assert.IsTrue(insertTask1.Task.Result);
         Assert.IsTrue(insertTask2.Task.Result);
@@ -273,11 +272,11 @@ public class PostgresChangesDeliveryTests
     public async Task OnPostgresChange_ShouldRegisterAndDeliver_GivenChainedSubscribe()
     {
         var tsc = new TaskCompletionSource<bool>();
-        await socketClient.Channel("public:todos")
+        await this.socketClient.Channel("public:todos")
             .OnPostgresChange((_, changes) => tsc.TrySetResult(changes.Model<Todo>() != null),
                 ListenType.Inserts, new PostgresChangesFilter { Table = "todos" })
             .Subscribe();
-        await restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "OnPostgresChange receives insert? ✅" });
+        await this.restClient.Table<Todo>().Insert(new Todo { UserId = 1, Details = "OnPostgresChange receives insert? ✅" });
         Assert.IsTrue(await WithinTimeout(tsc.Task));
     }
 

--- a/packages/Realtime/Realtime/Exceptions/FailureHint.cs
+++ b/packages/Realtime/Realtime/Exceptions/FailureHint.cs
@@ -48,6 +48,11 @@ public static class FailureHint
         /// If seen, please open an issue.
         /// </summary>
         ConnectionStale,
+
+        /// <summary>
+        /// Cannot make changes after subscribe
+        /// </summary>
+        StateInvalid,
     }
 
     /// <summary>

--- a/packages/Realtime/Realtime/Exceptions/FailureHint.cs
+++ b/packages/Realtime/Realtime/Exceptions/FailureHint.cs
@@ -1,4 +1,3 @@
-using System;
 using Websocket.Client;
 
 namespace Supabase.Realtime.Exceptions;

--- a/packages/Realtime/Realtime/Exceptions/FailureHint.cs
+++ b/packages/Realtime/Realtime/Exceptions/FailureHint.cs
@@ -68,7 +68,7 @@ public static class FailureHint
             DisconnectionType.NoMessageReceived => Reason.ConnectionStale,
             DisconnectionType.Lost => Reason.ConnectionLost,
             DisconnectionType.ByServer => Reason.Unknown,
-            _ => Reason.Unknown
+            _ => Reason.Unknown,
         };
     }
 }

--- a/packages/Realtime/Realtime/PublicAPI.Unshipped.txt
+++ b/packages/Realtime/Realtime/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ Supabase.Realtime.Channel.ChannelOptions.SerializerSettings.get -> System.Text.J
 Supabase.Realtime.Client.SerializerSettings.get -> System.Text.Json.JsonSerializerOptions!
 Supabase.Realtime.ClientOptions.WebSocketFactory.get -> Supabase.Realtime.Sockets.IWebSocketFactory?
 Supabase.Realtime.ClientOptions.WebSocketFactory.set -> void
+Supabase.Realtime.Exceptions.FailureHint.Reason.StateInvalid = 7 -> Supabase.Realtime.Exceptions.FailureHint.Reason
 Supabase.Realtime.Interfaces.IRealtimeClient<TSocket, TChannel>.SerializerSettings.get -> System.Text.Json.JsonSerializerOptions!
 Supabase.Realtime.PostgresChanges.PostgresChangesResponse.PostgresChangesResponse() -> void
 Supabase.Realtime.PostgresChanges.PostgresChangesResponse.PostgresChangesResponse(System.Text.Json.JsonSerializerOptions! serializerSettings) -> void

--- a/packages/Realtime/Realtime/RealtimeChannel.cs
+++ b/packages/Realtime/Realtime/RealtimeChannel.cs
@@ -443,6 +443,13 @@ public class RealtimeChannel : IRealtimeChannel
     /// <param name="postgresChangesOptions"></param>
     internal void RegisterPostgresChangesOptions(PostgresChangesOptions postgresChangesOptions)
     {
+        if (this.IsJoined || this.IsJoining)
+            throw new RealtimeException(
+                $"Cannot add `postgres_changes` callbacks for {this.Topic} after `Subscribe()`.")
+            {
+                Reason = FailureHint.Reason.StateInvalid,
+            };
+
         this.PostgresChangesOptions.Add(postgresChangesOptions);
         this.BindPostgresChangesOptions(postgresChangesOptions);
     }
@@ -534,7 +541,7 @@ public class RealtimeChannel : IRealtimeChannel
 
     /// <summary>
     /// Sends a `Push` request under this channel.
-    /// 
+    ///
     /// Maintains a buffer in the event push is called prior to the channel being joined.
     /// </summary>
     /// <param name="eventName"></param>
@@ -885,7 +892,7 @@ public class RealtimeChannel : IRealtimeChannel
     }
 
     /// <summary>
-    /// Try to invoke the handler properly based on event type and socket response 
+    /// Try to invoke the handler properly based on event type and socket response
     /// </summary>
     /// <param name="eventType"></param>
     /// <param name="response"></param>


### PR DESCRIPTION
- after subscribe on postgres changes it should throw exception if try to change its configuration

## What kind of change does this PR introduce?

feature

## What is the current behavior?


## What is the new behavior?

- throw a exception if try update config of postgres change after subscribe

## Additional context

- related to https://github.com/supabase-community/supabase-csharp/issues/242
