### PR TITLE
fix(postgrest): don't put a dot before nested and/or groups

### DIFF
--- a/packages/Postgrest/Postgrest.Tests/Filtering/FilterSerializationTests.cs
+++ b/packages/Postgrest/Postgrest.Tests/Filtering/FilterSerializationTests.cs
@@ -159,4 +159,56 @@ public class FilterSerializationTests
             (or.Key + "=" + or.Value).Should().Be("or=(a.gte.0,a.lte.100)");
         }
     }
+
+    [TestMethod]
+    public void PrepareFilter_ShouldDropTheDot_GivenNestedGroups()
+    {
+        var inner = new QueryFilter(Operator.And, new List<IPostgrestQueryFilter>
+        {
+            new QueryFilter("a", Operator.GreaterThanOrEqual, "0"),
+            new QueryFilter("a", Operator.LessThanOrEqual, "100")
+        });
+        var middle = new QueryFilter(Operator.Or, new List<IPostgrestQueryFilter>
+        {
+            inner,
+            new QueryFilter("b", Operator.Equals, "bar")
+        });
+        var outer = new QueryFilter(Operator.And, new List<IPostgrestQueryFilter>
+        {
+            middle,
+            new QueryFilter("c", Operator.Equals, "buzz")
+        });
+        var result = Prepare(outer);
+        (result.Key + "=" + result.Value).Should()
+            .Be("and=(or(and(a.gte.0,a.lte.100),b.eq.bar),c.eq.buzz)");
+    }
+
+    [TestMethod]
+    public void PrepareFilter_ShouldDropTheDot_GivenNegatedGroupInsideGroup()
+    {
+        var negated = new QueryFilter(Operator.Not, new QueryFilter(Operator.And, new List<IPostgrestQueryFilter>
+        {
+            new QueryFilter("a", Operator.GreaterThanOrEqual, "0"),
+            new QueryFilter("a", Operator.LessThanOrEqual, "100")
+        }));
+        var result = Prepare(new QueryFilter(Operator.Or, new List<IPostgrestQueryFilter>
+        {
+            negated,
+            new QueryFilter("b", Operator.Equals, "bar")
+        }));
+        (result.Key + "=" + result.Value).Should().Be("or=(not.and(a.gte.0,a.lte.100),b.eq.bar)");
+    }
+
+    [TestMethod]
+    public void PrepareFilter_ShouldKeepTheDot_GivenValueOperatorsInsideGroup()
+    {
+        var result = Prepare(new QueryFilter(Operator.Or, new List<IPostgrestQueryFilter>
+        {
+            new QueryFilter("foo", Operator.In, new List<object> { "bar", "buzz" }),
+            new QueryFilter("foo", Operator.Contains, new List<object> { "bar", "buzz" }),
+            new QueryFilter("foo", Operator.FTS, new FullTextSearchConfig("bar", "english"))
+        }));
+        (result.Key + "=" + result.Value).Should()
+            .Be("or=(foo.in.(\"bar\",\"buzz\"),foo.cs.{bar,buzz},foo.fts(english).bar)");
+    }
 }

--- a/packages/Postgrest/Postgrest.Tests/Linq/LinqQueryTests.cs
+++ b/packages/Postgrest/Postgrest.Tests/Linq/LinqQueryTests.cs
@@ -59,6 +59,16 @@ public class LinqQueryTests
     }
 
     [TestMethod]
+    public async Task Where_ShouldSelectRowsMatchingAnyBranch_GivenThreeChainedOrs()
+    {
+        var client = LocalStack.Client();
+        var response = await client.Table<User>()
+            .Where(x => x.Username == "supabot" || x.Username == "kiwicopple" || x.Status == "OFFLINE").Get();
+        response.Models.Should()
+            .OnlyContain(m => m.Username == "supabot" || m.Username == "kiwicopple" || m.Status == "OFFLINE");
+    }
+
+    [TestMethod]
     public async Task Or_ShouldSelectRowsMatchingAnyBranch()
     {
         var client = LocalStack.Client();

--- a/packages/Postgrest/Postgrest.Tests/Linq/WhereClauseTests.cs
+++ b/packages/Postgrest/Postgrest.Tests/Linq/WhereClauseTests.cs
@@ -4,15 +4,15 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Postgrest.Tests.Models;
 using Supabase.Postgrest;
-using static Supabase.Postgrest.Constants;
 
 namespace Postgrest.Tests.Linq;
 
 /// <summary>
 ///     How a LINQ <c>Where</c> predicate is translated into PostgREST query syntax, asserted on the generated
-///     URL so no network is involved. Covers negation, null-checks, logical grouping, boolean members, and
-///     the <c>Contains</c> disambiguation between a captured collection (<c>in</c>) and a column (<c>cs</c>/<c>like</c>);
-///     unsupported predicates are rejected with a descriptive <see cref="ArgumentException" /> (supabase-csharp#192).
+///     URL so no network is involved. Covers negation, null-checks, logical grouping (nested groups render
+///     dotless, supabase-csharp#336), boolean members, and the <c>Contains</c> disambiguation between a
+///     captured collection (<c>in</c>) and a column (<c>cs</c>/<c>like</c>); unsupported predicates are
+///     rejected with a descriptive <see cref="ArgumentException" /> (supabase-csharp#192).
 /// </summary>
 [TestClass]
 [TestCategory("Unit")]
@@ -25,7 +25,7 @@ public class WhereClauseTests
     public void Where_ShouldApplyNoFilter_GivenAnAbsentDelegateNullCheck()
     {
         var requestModel = new UserRequestModel();
-        client.Table<User>().Where(x => requestModel.FilterPredicate == null || requestModel.FilterPredicate(x))
+        this.client.Table<User>().Where(x => requestModel.FilterPredicate == null || requestModel.FilterPredicate(x))
             .GenerateUrl().Should().Be($"{BaseUrl}/users");
     }
 
@@ -33,7 +33,7 @@ public class WhereClauseTests
     public void Where_ShouldThrowDescriptive_GivenAPresentDelegateItCannotTranslate()
     {
         var requestModel = new UserRequestModel { FilterPredicate = u => u.Username == "supabot" };
-        var act = () => client.Table<User>()
+        var act = () => this.client.Table<User>()
             .Where(x => requestModel.FilterPredicate == null || requestModel.FilterPredicate(x));
         act.Should().Throw<ArgumentException>().WithMessage("*Unable to translate expression*");
     }
@@ -42,7 +42,7 @@ public class WhereClauseTests
     public void Where_ShouldThrowDescriptive_GivenAnAlwaysFalsePredicate()
     {
         var requestModel = new UserRequestModel();
-        var act = () => client.Table<User>()
+        var act = () => this.client.Table<User>()
             .Where(x => requestModel.FilterPredicate != null && requestModel.FilterPredicate(x));
         act.Should().Throw<ArgumentException>().WithMessage("*always evaluates to false*");
     }
@@ -50,35 +50,73 @@ public class WhereClauseTests
     [TestMethod]
     public void Where_ShouldTranslateToIsNull_GivenANullCheckInsideAnOrPredicate()
     {
-        client.Table<User>().Where(x => x.Catchphrase == null || x.Catchphrase == "fat cat")
+        this.client.Table<User>().Where(x => x.Catchphrase == null || x.Catchphrase == "fat cat")
             .GenerateUrl().Should().Be($"{BaseUrl}/users?or=(catchphrase.is.null%2ccatchphrase.eq.fat+cat)");
     }
 
     [TestMethod]
     public void Where_ShouldNegateEqualityIntoNotEq()
     {
-        client.Table<User>().Where(x => !(x.Username == "supabot"))
+        this.client.Table<User>().Where(x => !(x.Username == "supabot"))
             .GenerateUrl().Should().Be($"{BaseUrl}/users?username=not.eq.supabot");
     }
 
     [TestMethod]
     public void Where_ShouldNegateNullCheckIntoNotIsNull()
     {
-        client.Table<User>().Where(x => !(x.Catchphrase == null))
+        this.client.Table<User>().Where(x => !(x.Catchphrase == null))
             .GenerateUrl().Should().Be($"{BaseUrl}/users?catchphrase=not.is.null");
     }
 
     [TestMethod]
     public void Where_ShouldNegateGroupedPredicateIntoNotWrappedLogicalFilter()
     {
-        client.Table<User>().Where(x => !(x.Catchphrase == "fat cat" || x.Username == "supabot"))
+        this.client.Table<User>().Where(x => !(x.Catchphrase == "fat cat" || x.Username == "supabot"))
             .GenerateUrl().Should().Be($"{BaseUrl}/users?not.or=(catchphrase.eq.fat+cat%2cusername.eq.supabot)");
+    }
+
+    [TestMethod]
+    public void Where_ShouldDropTheDot_GivenThreeChainedOrs()
+    {
+        const string search = "Ran";
+        this.client.Table<User>()
+            .Where(x => x.Catchphrase!.Contains(search) || x.FavoriteName!.Contains(search) ||
+                        x.Username!.Contains(search))
+            .GenerateUrl().Should()
+            .Be($"{BaseUrl}/users?or=(or(catchphrase.like.*Ran*%2cfavorite_name.like.*Ran*)%2cusername.like.*Ran*)");
+    }
+
+    [TestMethod]
+    public void Where_ShouldDropTheDot_GivenAnAndGroupInsideAnOrPredicate()
+    {
+        this.client.Table<User>()
+            .Where(x => x.Username == "supabot" || (x.Catchphrase == "fat cat" && x.Status == "ONLINE"))
+            .GenerateUrl().Should()
+            .Be($"{BaseUrl}/users?or=(username.eq.supabot%2cand(catchphrase.eq.fat+cat%2cstatus.eq.ONLINE))");
+    }
+
+    [TestMethod]
+    public void Where_ShouldDropTheDot_GivenANegatedAndGroupInsideAnOrPredicate()
+    {
+        this.client.Table<User>()
+            .Where(x => !(x.Catchphrase == "fat cat" && x.Username == "supabot") || x.Status == "ONLINE")
+            .GenerateUrl().Should()
+            .Be($"{BaseUrl}/users?or=(not.and(catchphrase.eq.fat+cat%2cusername.eq.supabot)%2cstatus.eq.ONLINE)");
+    }
+
+    [TestMethod]
+    public void Where_ShouldKeepTheDot_GivenNegatedColumnFiltersInsideAGroup()
+    {
+        this.client.Table<User>()
+            .Where(x => x.Catchphrase != null && !(x.Username == "supabot"))
+            .GenerateUrl().Should()
+            .Be($"{BaseUrl}/users?and=(catchphrase.not.is.null%2cusername.not.eq.supabot)");
     }
 
     [TestMethod]
     public void Where_ShouldNegateStringContainsIntoNotLike()
     {
-        client.Table<User>().Where(x => !x.Username!.Contains("supa"))
+        this.client.Table<User>().Where(x => !x.Username!.Contains("supa"))
             .GenerateUrl().Should().Be($"{BaseUrl}/users?username=not.like.*supa*");
     }
 
@@ -86,7 +124,7 @@ public class WhereClauseTests
     public void Where_ShouldTranslateCapturedListContainsColumnIntoIn()
     {
         var values = new List<string> { "a", "b" };
-        client.Table<KitchenSink>().Where(x => values.Contains(x.StringValue!))
+        this.client.Table<KitchenSink>().Where(x => values.Contains(x.StringValue!))
             .GenerateUrl().Should().Be($"{BaseUrl}/kitchen_sink?string_value=in.(\"a\"%2c\"b\")");
     }
 
@@ -94,49 +132,49 @@ public class WhereClauseTests
     public void Where_ShouldTranslateCapturedArrayContainsColumnIntoIn()
     {
         var values = new[] { 1, 2 };
-        client.Table<KitchenSink>().Where(x => values.Contains(x.IntValue!.Value))
+        this.client.Table<KitchenSink>().Where(x => values.Contains(x.IntValue!.Value))
             .GenerateUrl().Should().Be($"{BaseUrl}/kitchen_sink?int_value=in.(\"1\"%2c\"2\")");
     }
 
     [TestMethod]
     public void Where_ShouldTranslateColumnListContainsConstantIntoContains()
     {
-        client.Table<KitchenSink>().Where(x => x.ListOfStrings!.Contains("set"))
+        this.client.Table<KitchenSink>().Where(x => x.ListOfStrings!.Contains("set"))
             .GenerateUrl().Should().Be($"{BaseUrl}/kitchen_sink?list_of_strings=cs.{{set}}");
     }
 
     [TestMethod]
     public void Where_ShouldTranslateColumnStringContainsConstantIntoLike()
     {
-        client.Table<KitchenSink>().Where(x => x.StringValue!.Contains("foo"))
+        this.client.Table<KitchenSink>().Where(x => x.StringValue!.Contains("foo"))
             .GenerateUrl().Should().Be($"{BaseUrl}/kitchen_sink?string_value=like.*foo*");
     }
 
     [TestMethod]
     public void Where_ShouldTranslateBareBooleanMemberIntoEqTrue()
     {
-        client.Table<KitchenSink>().Where(x => x.BooleanValue)
+        this.client.Table<KitchenSink>().Where(x => x.BooleanValue)
             .GenerateUrl().Should().Be($"{BaseUrl}/kitchen_sink?bool_value=eq.True");
     }
 
     [TestMethod]
     public void Where_ShouldTranslateNegatedBooleanMemberIntoNotEqTrue()
     {
-        client.Table<KitchenSink>().Where(x => !x.BooleanValue)
+        this.client.Table<KitchenSink>().Where(x => !x.BooleanValue)
             .GenerateUrl().Should().Be($"{BaseUrl}/kitchen_sink?bool_value=not.eq.True");
     }
 
     [TestMethod]
     public void Where_ShouldNestBooleanMember_GivenAnAndPredicate()
     {
-        client.Table<KitchenSink>().Where(x => x.BooleanValue && x.IntValue > 3)
+        this.client.Table<KitchenSink>().Where(x => x.BooleanValue && x.IntValue > 3)
             .GenerateUrl().Should().Be($"{BaseUrl}/kitchen_sink?and=(bool_value.eq.True%2cint_value.gt.3)");
     }
 
     [TestMethod]
     public void Where_ShouldThrowDescriptive_GivenTwoColumnsCompared()
     {
-        var act = () => client.Table<KitchenSink>().Where(x => x.DateTimeValue < x.DateTimeValue1);
+        var act = () => this.client.Table<KitchenSink>().Where(x => x.DateTimeValue < x.DateTimeValue1);
         act.Should().Throw<ArgumentException>().WithMessage("*cannot compare two model columns*");
     }
 

--- a/packages/Postgrest/Postgrest/Table.cs
+++ b/packages/Postgrest/Postgrest/Table.cs
@@ -777,18 +777,18 @@ public class Table<TModel> : IPostgrestTable<TModel> where TModel : BaseModel, n
             case Operator.And:
                 if (filter.Criteria is List<IPostgrestQueryFilter> subFilters)
                 {
-                    var list = new List<KeyValuePair<string, string>>();
                     foreach (var subFilter in subFilters)
                     {
                         if (subFilter == null)
                             throw new ArgumentException(
                                 $"Expected all filters supplied to a `{filter.Op}` filter to be non-null.");
 
-                        list.Add(this.PrepareFilter(subFilter));
-                    }
+                        var preppedFilter = this.PrepareFilter(subFilter);
 
-                    foreach (var preppedFilter in list)
-                        strBuilder.Append($"{preppedFilter.Key}.{preppedFilter.Value},");
+                        // PostgREST wants `or(a,b)`, not `or.(a,b)` - only column filters take the dot (issue #336).
+                        var separator = IsLogicalGroup(subFilter) ? "" : ".";
+                        strBuilder.Append($"{preppedFilter.Key}{separator}{preppedFilter.Value},");
+                    }
 
                     return new KeyValuePair<string, string>(asAttribute.Mapping,
                         $"({strBuilder.ToString().Trim(',')})");
@@ -888,6 +888,10 @@ public class Table<TModel> : IPostgrestTable<TModel> where TModel : BaseModel, n
         inner.Op is Operator.And or Operator.Or
             ? new KeyValuePair<string, string>($"not.{prepared.Key}", prepared.Value)
             : new KeyValuePair<string, string>(prepared.Key, $"not.{prepared.Value}");
+
+    private static bool IsLogicalGroup(IPostgrestQueryFilter filter) =>
+        filter.Op is Operator.And or Operator.Or ||
+        (filter.Op is Operator.Not && filter.Criteria is QueryFilter { Op: Operator.And or Operator.Or });
 
     /// <inheritdoc />
     public void Clear()


### PR DESCRIPTION
closes #336

three or more `||` terms nest, and the nested group got a dot, which postgrest rejects:

    before  or=(or.(first_name.like.*Ran*,middle_name.like.*Ran*),last_name.like.*Ran*)   400 PGRST100
    after   or=(or(first_name.like.*Ran*,middle_name.like.*Ran*),last_name.like.*Ran*)    200

only column filters take the dot, a group is already parenthesized. negated groups nest as not.and(...).

also fixes .Or()/.And() with a nested group, both go through PrepareFilter.

didn't flatten to or=(a,b,c) - that was tried in supabase-community/postgrest-csharp#110 and needs a visitor rewrite. the nested form is valid.
