### PR TITLE
fix(gotrue): do not redirect on the link identity flow

### DIFF
--- a/packages/Gotrue/Gotrue.Tests/Authentication/LinkIdentityContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Authentication/LinkIdentityContractTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Gotrue.Tests.Support;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Supabase.Gotrue;
+using Supabase.Gotrue.Exceptions;
 using Supabase.Gotrue.Interfaces;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -61,5 +62,17 @@ public class LinkIdentityContractTests
 
         state.Uri.ToString().Should().Be("https://provider.example.com/authorize?client_id=abc",
             "the provider URL returned in the body replaces the one the SDK would have been redirected to");
+    }
+
+    [TestMethod]
+    public async Task LinkIdentity_ShouldThrow_GivenResponseWithoutProviderUrl()
+    {
+        this.server.Given(Request.Create().WithPath("/user/identities/authorize").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody("{}"));
+
+        var link = () => this.api.LinkIdentity("user-access-token", Constants.Provider.Google,
+            new SignInOptions { FlowType = Constants.OAuthFlowType.PKCE });
+
+        await link.Should().ThrowAsync<GotrueException>("returning the un-redirected SDK-built url would silently send the caller to an endpoint that rejects the request");
     }
 }

--- a/packages/Gotrue/Gotrue.Tests/Authentication/LinkIdentityContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Authentication/LinkIdentityContractTests.cs
@@ -1,0 +1,65 @@
+#region
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Gotrue.Tests.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Gotrue;
+using Supabase.Gotrue.Interfaces;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+#endregion
+
+namespace Gotrue.Tests.Authentication;
+
+/// <summary>
+///     Pins the request LinkIdentity puts on the wire for the OAuth (PKCE) flow: it must ask GoTrue for the
+///     provider URL in the response body rather than take a 302.
+/// </summary>
+[TestClass]
+[TestCategory("Contract")]
+public class LinkIdentityContractTests
+{
+    private const string AuthorizeResponse =
+        """
+        { "url": "https://provider.example.com/authorize?client_id=abc" }
+        """;
+
+    private IGotrueApi<User, Session> api = null!;
+    private MockGotrueServer server = null!;
+
+    [TestInitialize]
+    public void TestInitializer()
+    {
+        this.server = new MockGotrueServer();
+        this.api = new Api(this.server.Url);
+    }
+
+    [TestCleanup]
+    public void TestCleanup() => this.server.Dispose();
+
+    [TestMethod]
+    public async Task LinkIdentity_ShouldSkipTheHttpRedirect_GivenProvider()
+    {
+        // Issue #378: without skip_http_redirect HttpClient follows GoTrue's 302 and drops the
+        // Authorization/apikey headers on the cross-domain hop, so Kong rejects the request with
+        // "No API key found in request".
+        this.server.Given(Request.Create().WithPath("/user/identities/authorize").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody(AuthorizeResponse));
+
+        var state = await this.api.LinkIdentity("user-access-token", Constants.Provider.Google,
+            new SignInOptions { FlowType = Constants.OAuthFlowType.PKCE });
+
+        this.server.VerifySingleReceivedRequest()
+            .WithMethod(HttpMethod.Get)
+            .WithPath("/user/identities/authorize")
+            .WithQueryParam("skip_http_redirect", "true")
+            .WithQueryParam("provider", "google")
+            .WithHeader("Authorization", "Bearer user-access-token");
+
+        state.Uri.ToString().Should().Be("https://provider.example.com/authorize?client_id=abc",
+            "the provider URL returned in the body replaces the one the SDK would have been redirected to");
+    }
+}

--- a/packages/Gotrue/Gotrue/Api.cs
+++ b/packages/Gotrue/Gotrue/Api.cs
@@ -589,21 +589,20 @@ public class Api : IGotrueApi<User, Session>
     {
         var state = Helpers.GetUrlForProvider($"{this.Url}/user/identities/authorize", provider, options);
 
-        // Ask the server to return the provider URL in the response body instead of issuing
-        // a 302 redirect. Without this, HttpClient follows the redirect chain and drops the
-        // Authorization/apikey headers on cross-domain hops, causing Kong to reject the
-        // request with "No API key found in request". This matches auth-js behavior.
+        // Need to skip the HTTP redirect to avoid "No API key found in request" error and match auth-js behavior
         var uri = Helpers.AddQueryParams(state.Uri.ToString(), new Dictionary<string, string> { { "skip_http_redirect", "true" } });
         var response = await this.MakeRequestAsync(HttpMethod.Get, uri.ToString(), null, this.CreateAuthedRequestHeaders(token));
 
-        if (!string.IsNullOrEmpty(response?.Content))
-        {
-            var payload = JsonSerializer.Deserialize<Dictionary<string, string>>(response.Content);
-            if (payload != null && payload.TryGetValue("url", out var url) && !string.IsNullOrEmpty(url))
-            {
-                state.Uri = new Uri(url);
-            }
-        }
+        var content = response?.Content;
+
+        Dictionary<string, string>? payload = null;
+        if (!string.IsNullOrEmpty(content))
+            payload = JsonSerializer.Deserialize<Dictionary<string, string>>(content);
+
+        if (payload == null || !payload.TryGetValue("url", out var url) || string.IsNullOrEmpty(url))
+            throw new GotrueException("Gotrue did not return a provider authorization url for the identity link.", FailureHint.Reason.BadSessionUrl);
+
+        state.Uri = new Uri(url);
 
         return state;
     }

--- a/packages/Gotrue/Gotrue/Api.cs
+++ b/packages/Gotrue/Gotrue/Api.cs
@@ -588,7 +588,23 @@ public class Api : IGotrueApi<User, Session>
     public async Task<ProviderAuthState> LinkIdentity(string token, Provider provider, SignInOptions options)
     {
         var state = Helpers.GetUrlForProvider($"{this.Url}/user/identities/authorize", provider, options);
-        await this.MakeRequestAsync(HttpMethod.Get, state.Uri.ToString(), null, this.CreateAuthedRequestHeaders(token));
+
+        // Ask the server to return the provider URL in the response body instead of issuing
+        // a 302 redirect. Without this, HttpClient follows the redirect chain and drops the
+        // Authorization/apikey headers on cross-domain hops, causing Kong to reject the
+        // request with "No API key found in request". This matches auth-js behavior.
+        var uri = Helpers.AddQueryParams(state.Uri.ToString(), new Dictionary<string, string> { { "skip_http_redirect", "true" } });
+        var response = await this.MakeRequestAsync(HttpMethod.Get, uri.ToString(), null, this.CreateAuthedRequestHeaders(token));
+
+        if (!string.IsNullOrEmpty(response?.Content))
+        {
+            var payload = JsonSerializer.Deserialize<Dictionary<string, string>>(response.Content);
+            if (payload != null && payload.TryGetValue("url", out var url) && !string.IsNullOrEmpty(url))
+            {
+                state.Uri = new Uri(url);
+            }
+        }
+
         return state;
     }
 

--- a/packages/Gotrue/Gotrue/Interfaces/IGotrueApi.cs
+++ b/packages/Gotrue/Gotrue/Interfaces/IGotrueApi.cs
@@ -61,6 +61,7 @@ namespace Supabase.Gotrue.Interfaces
 		/// <param name="provider">Provider to Link</param>
 		/// <param name="options"></param>
 		/// <returns></returns>
+		/// <exception cref="Exceptions.GotrueException">Thrown when the server response does not contain a provider authorization url.</exception>
 		Task<ProviderAuthState> LinkIdentity(string token, Provider provider, SignInOptions options);
 
 		/// <summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes #378 

## What is the current behavior?

There is an error trying to link an identity through the PKCE flow

## What is the new behavior?

Successfully links the identity through the PKCE flow instead of getting stuck on the apikey error.
