### PR TITLE
fix(gotrue,supabase): session persistence end to end

### DIFF
--- a/docs/migrations/v8.0.0.md
+++ b/docs/migrations/v8.0.0.md
@@ -306,3 +306,17 @@ var auth = await client.SignIn(Provider.Google, new SignInOptions
 // On the callback, validate the `csrf` query param, then exchange the code:
 // await client.ExchangeCodeForSession(storedPkceVerifier, code);
 ```
+
+## 8. Gotrue: a failed token refresh no longer signs the user out
+
+**Why:** `RetrieveSessionAsync` destroyed the session on any refresh failure, so
+starting an app without connectivity wiped the persisted session and forced a new
+login. Now only a rejection the server reports as an invalid refresh token
+signs the user out; a network error, timeout or 5xx keeps the session so the
+next refresh can retry. For the same reason the method returns the loaded
+session instead of throwing when the client is marked offline.
+
+**What you need to do:** nothing, unless you relied on a `null` return, the
+thrown offline exception, or the `SignedOut` event to detect a failed refresh:
+a returned session is no longer a guarantee that its access token is still
+valid.

--- a/docs/migrations/v8.0.0.md
+++ b/docs/migrations/v8.0.0.md
@@ -311,7 +311,7 @@ var auth = await client.SignIn(Provider.Google, new SignInOptions
 
 **Why:** `RetrieveSessionAsync` destroyed the session on any refresh failure, so
 starting an app without connectivity wiped the persisted session and forced a new
-login. Now only a rejection the server reports as an invalid refresh token
+login ([#390](https://github.com/supabase-community/supabase-csharp/issues/390)). Now only a rejection the server reports as an invalid refresh token
 signs the user out; a network error, timeout or 5xx keeps the session so the
 next refresh can retry. For the same reason the method returns the loaded
 session instead of throwing when the client is marked offline.

--- a/docs/migrations/v8.0.0.md
+++ b/docs/migrations/v8.0.0.md
@@ -328,4 +328,5 @@ client never called `LoadSession`, so a configured `SessionHandler` was written
 to and never read and every restart started signed out.
 
 **What you need to do:** nothing. A manual `supabase.Auth.LoadSession()` before
-`InitializeAsync()` is harmless but redundant now.
+`InitializeAsync()` is harmless but redundant now. Note the restored start raises
+`UserUpdated` (and `TokenRefreshed` after the refresh), not `SignedIn`.

--- a/docs/migrations/v8.0.0.md
+++ b/docs/migrations/v8.0.0.md
@@ -320,13 +320,3 @@ session instead of throwing when the client is marked offline.
 thrown offline exception, or the `SignedOut` event to detect a failed refresh:
 a returned session is no longer a guarantee that its access token is still
 valid.
-
-## 9. `InitializeAsync` now restores the persisted session
-
-**Why:** the readme and `ISupabaseClient` docs always promised it, but the
-client never called `LoadSession`, so a configured `SessionHandler` was written
-to and never read and every restart started signed out.
-
-**What you need to do:** nothing. A manual `supabase.Auth.LoadSession()` before
-`InitializeAsync()` is harmless but redundant now. Note the restored start raises
-`UserUpdated` (and `TokenRefreshed` after the refresh), not `SignedIn`.

--- a/docs/migrations/v8.0.0.md
+++ b/docs/migrations/v8.0.0.md
@@ -320,3 +320,12 @@ session instead of throwing when the client is marked offline.
 thrown offline exception, or the `SignedOut` event to detect a failed refresh:
 a returned session is no longer a guarantee that its access token is still
 valid.
+
+## 9. `InitializeAsync` now restores the persisted session
+
+**Why:** the readme and `ISupabaseClient` docs always promised it, but the
+client never called `LoadSession`, so a configured `SessionHandler` was written
+to and never read and every restart started signed out.
+
+**What you need to do:** nothing. A manual `supabase.Auth.LoadSession()` before
+`InitializeAsync()` is harmless but redundant now.

--- a/packages/Gotrue/Gotrue.Tests/Observability/ObservabilityContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Observability/ObservabilityContractTests.cs
@@ -197,7 +197,7 @@ public class ObservabilityContractTests
         server.Reset();
         MockTokenFailure();
         var session = await client.RetrieveSessionAsync();
-        session.Should().BeNull("the failed refresh destroys the session");
+        session.Should().NotBeNull("a 5xx is transient, so the session is kept");
         messages.Should().NotBeEmpty("the failed refresh should be reported to debug listeners");
         messages.Should().OnlyContain(message =>
                 !message.Contains("new-access-token") && !message.Contains("new-refresh-token"),

--- a/packages/Gotrue/Gotrue.Tests/Support/TestClients.cs
+++ b/packages/Gotrue/Gotrue.Tests/Support/TestClients.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using Supabase.Gotrue;
 using Supabase.Gotrue.Interfaces;
 using static Gotrue.Tests.TestUtils;
@@ -43,11 +44,12 @@ internal static class TestClients
     internal static IGotrueAdminClient<User> AdminAgainstCliStack(string serviceKey) =>
         new AdminClient(serviceKey, CliOptions());
 
-    internal static IGotrueClient<User, Session> Against(MockGotrueServer server) =>
+    internal static IGotrueClient<User, Session> Against(MockGotrueServer server, bool autoRefreshToken = false, HttpClient? httpClient = null) =>
         new Client(new ClientOptions
         {
             Url = server.Url,
-            AutoRefreshToken = false,
+            AutoRefreshToken = autoRefreshToken,
+            HttpClient = httpClient,
             AllowUnconfirmedUserSessions = false,
             Headers = new Dictionary<string, string> { { "apikey", MockGotrueServer.ApiKey } },
         });

--- a/packages/Gotrue/Gotrue.Tests/TestUtils.cs
+++ b/packages/Gotrue/Gotrue.Tests/TestUtils.cs
@@ -43,9 +43,12 @@ public static class TestUtils
     public static string GenerateServiceRoleToken(string jwtSecret)
     {
         var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret));
+        // Backdated so sub-second clock skew against the containerized server cannot fail gotrue's zero-leeway nbf check.
+        var issuedAt = DateTime.UtcNow.AddMinutes(-1);
         var tokenDescriptor = new SecurityTokenDescriptor
         {
-            IssuedAt = DateTime.UtcNow,
+            IssuedAt = issuedAt,
+            NotBefore = issuedAt,
             Expires = DateTime.UtcNow.AddDays(7),
             SigningCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256Signature),
             Claims = new Dictionary<string, object> { { "role", "service_role" } },

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/Fixtures/token_success_expiring.json
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/Fixtures/token_success_expiring.json
@@ -1,0 +1,10 @@
+{
+  "access_token": "new-access-token",
+  "refresh_token": "new-refresh-token",
+  "token_type": "bearer",
+  "expires_in": 1,
+  "user": {
+    "id": "user-id-123",
+    "aud": "authenticated"
+  }
+}

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -104,6 +104,50 @@ public class SessionRestoreContractTests
         client.Shutdown();
     }
 
+    [TestMethod]
+    public async Task RefreshToken_ShouldShareOneAttempt_GivenConcurrentCallers()
+    {
+        this.server
+            .Given(Request.Create().WithPath("/token").UsingPost())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(Fixture("token_success.json")));
+        var client = this.Restore(TestClients.Against(this.server));
+        var first = client.RefreshToken();
+        var second = client.RefreshToken();
+        second.Should().BeSameAs(first, "a refresh token is single-use, so concurrent refreshes must share one attempt");
+        await Task.WhenAll(first, second);
+        var third = client.RefreshToken();
+        third.Should().NotBeSameAs(first, "a completed attempt must not be reused");
+        await third;
+    }
+
+    [TestMethod]
+    public async Task RefreshToken_ShouldRetryAfterAFailedAttempt_GivenSequentialCallers()
+    {
+        var handler = new UnreachableHandler();
+        var client = this.Restore(TestClients.Against(this.server, httpClient: new HttpClient(handler)));
+        for (var i = 0; i < 2; i++)
+        {
+            var act = () => client.RefreshToken();
+            await act.Should().ThrowAsync<Exception>();
+        }
+        handler.Attempts.Should().Be(2, "a failed attempt must not be cached as the in-flight refresh");
+    }
+
+    [TestMethod]
+    public void LoadSession_ShouldNotThrow_GivenAStoreThatFailsToLoad()
+    {
+        var store = Substitute.For<IGotrueSessionPersistence<Session>>();
+        store.LoadSession().Returns(_ => throw new IOException("locked"));
+        var client = TestClients.Against(this.server);
+        client.SetPersistence(store);
+        var act = () => client.LoadSession();
+        act.Should().NotThrow();
+        client.CurrentSession.Should().BeNull();
+    }
+
     private IGotrueClient<User, Session> Restore(IGotrueClient<User, Session> client)
     {
         client.SetPersistence(this.persistence);

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -1,0 +1,103 @@
+#region
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Gotrue.Tests.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Supabase.Gotrue;
+using Supabase.Gotrue.Interfaces;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+#endregion
+
+namespace Gotrue.Tests.TokenRefresh;
+
+/// <summary>
+///     Pins how a restored session survives startup: only a server-rejected refresh token signs the
+///     user out - a network error or an offline client keeps the persisted session (issue #390).
+/// </summary>
+[TestClass]
+[TestCategory("Contract")]
+public class SessionRestoreContractTests
+{
+    private IGotrueSessionPersistence<Session> persistence = null!;
+    private MockGotrueServer server = null!;
+
+    [TestInitialize]
+    public void TestInitializer()
+    {
+        this.server = new MockGotrueServer();
+        this.persistence = SessionPersistenceSubstitute.Tracking();
+        this.persistence.SaveSession(new Session { AccessToken = "an-access-token", RefreshToken = "a-refresh-token", ExpiresIn = 3600 });
+    }
+
+    [TestCleanup]
+    public void TestCleanup() => this.server.Dispose();
+
+    [TestMethod]
+    public async Task RetrieveSessionAsync_ShouldKeepTheSession_GivenTheRefreshFailsWithANetworkError()
+    {
+        var client = this.Restore(TestClients.Against(this.server, autoRefreshToken: true, new HttpClient(new UnreachableHandler())));
+        var session = await client.RetrieveSessionAsync();
+        session.Should().NotBeNull("an offline start must not sign the user out");
+        client.CurrentSession.Should().BeSameAs(session);
+        this.persistence.DidNotReceive().DestroySession();
+        client.Shutdown();
+    }
+
+    [TestMethod]
+    public async Task RetrieveSessionAsync_ShouldDestroyTheSession_GivenTheServerRejectsTheRefreshToken()
+    {
+        this.server
+            .Given(Request.Create().WithPath("/token").UsingPost())
+            .RespondWith(Response.Create()
+                .WithStatusCode(400)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(Fixture("token_not_found_error.json")));
+        var client = this.Restore(TestClients.Against(this.server, autoRefreshToken: true));
+        var session = await client.RetrieveSessionAsync();
+        session.Should().BeNull();
+        client.CurrentSession.Should().BeNull();
+        this.persistence.Received().DestroySession();
+        client.Shutdown();
+    }
+
+    [TestMethod]
+    public async Task RetrieveSessionAsync_ShouldKeepTheSession_GivenTheClientIsMarkedOffline()
+    {
+        var client = this.Restore(TestClients.Against(this.server, autoRefreshToken: true));
+        client.Online = false;
+        var session = await client.RetrieveSessionAsync();
+        session.Should().NotBeNull("an offline client cannot refresh, but must not lose the session");
+        client.CurrentSession.Should().BeSameAs(session);
+        this.persistence.DidNotReceive().DestroySession();
+        client.Shutdown();
+    }
+
+    private IGotrueClient<User, Session> Restore(IGotrueClient<User, Session> client)
+    {
+        client.SetPersistence(this.persistence);
+        client.LoadSession();
+        return client;
+    }
+
+    private static string Fixture(string name) =>
+        File.ReadAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TokenRefresh", "Fixtures", name));
+
+    private sealed class UnreachableHandler : HttpMessageHandler
+    {
+        public int Attempts;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref this.Attempts);
+            throw new HttpRequestException("connection refused");
+        }
+    }
+}

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -163,6 +163,21 @@ public class SessionRestoreContractTests
     }
 
     [TestMethod]
+    public async Task RetrieveSessionAsync_ShouldReturnTheReplacement_GivenTheRejectedRefreshWasForAReplacedSession()
+    {
+        var handler = new GatedHandler(HttpStatusCode.BadRequest, "token_not_found_error.json");
+        var client = this.Restore(TestClients.Against(this.server, autoRefreshToken: true, new HttpClient(handler)));
+        var retrieve = client.RetrieveSessionAsync();
+        this.persistence.SaveSession(new Session { AccessToken = "another-access-token", RefreshToken = "another-refresh-token", ExpiresIn = 3600 });
+        client.LoadSession();
+        handler.Release();
+        var session = await retrieve;
+        session!.RefreshToken.Should().Be("another-refresh-token",
+            "the rejection was for the replaced session, so the live one must be returned, not null");
+        this.persistence.DidNotReceive().DestroySession();
+    }
+
+    [TestMethod]
     public void LoadSession_ShouldClearTheSession_GivenTheStoreWasEmptied()
     {
         var client = this.Restore(TestClients.Against(this.server));
@@ -221,7 +236,7 @@ public class SessionRestoreContractTests
     ///     Answers every request with a successful refresh, but not before the test opens the gate - so a
     ///     refresh can be held in flight while the test does something to the session behind its back.
     /// </summary>
-    private sealed class GatedHandler : HttpMessageHandler
+    private sealed class GatedHandler(HttpStatusCode status = HttpStatusCode.OK, string fixture = "token_success.json") : HttpMessageHandler
     {
         private readonly TaskCompletionSource<bool> gate = new();
 
@@ -233,9 +248,9 @@ public class SessionRestoreContractTests
         {
             Interlocked.Increment(ref this.Attempts);
             await this.gate.Task;
-            return new HttpResponseMessage(HttpStatusCode.OK)
+            return new HttpResponseMessage(status)
             {
-                Content = new StringContent(Fixture("token_success.json"), Encoding.UTF8, "application/json"),
+                Content = new StringContent(Fixture(fixture), Encoding.UTF8, "application/json"),
             };
         }
     }

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -1,10 +1,13 @@
 #region
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -12,9 +15,11 @@ using Gotrue.Tests.Support;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using Supabase.Gotrue;
+using Supabase.Gotrue.Exceptions;
 using Supabase.Gotrue.Interfaces;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
+using static Supabase.Gotrue.Constants.AuthState;
 
 #endregion
 
@@ -28,6 +33,12 @@ namespace Gotrue.Tests.TokenRefresh;
 [TestCategory("Contract")]
 public class SessionRestoreContractTests
 {
+    /// <summary>Bounds every wait on a handler, so a bug fails the test in seconds instead of hanging it.</summary>
+    private static readonly TimeSpan HandlerTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>Every client the test built, shut down centrally so a failed assertion cannot leak its refresh timer.</summary>
+    private readonly List<IGotrueClient<User, Session>> clients = new();
+
     private IGotrueSessionPersistence<Session> persistence = null!;
     private MockGotrueServer server = null!;
 
@@ -40,7 +51,20 @@ public class SessionRestoreContractTests
     }
 
     [TestCleanup]
-    public void TestCleanup() => this.server.Dispose();
+    public void TestCleanup()
+    {
+        try
+        {
+            foreach (var client in this.clients)
+            {
+                client.Shutdown();
+            }
+        }
+        finally
+        {
+            this.server.Dispose();
+        }
+    }
 
     [TestMethod]
     public async Task RetrieveSessionAsync_ShouldKeepTheSession_GivenTheRefreshFailsWithANetworkError()
@@ -49,7 +73,6 @@ public class SessionRestoreContractTests
         var session = await client.RetrieveSessionAsync();
         session.Should().NotBeNull("an offline start must not sign the user out");
         this.persistence.DidNotReceive().DestroySession();
-        client.Shutdown();
     }
 
     [TestMethod]
@@ -66,7 +89,6 @@ public class SessionRestoreContractTests
         session.Should().BeNull();
         client.CurrentSession.Should().BeNull();
         this.persistence.Received().DestroySession();
-        client.Shutdown();
     }
 
     [TestMethod]
@@ -77,18 +99,18 @@ public class SessionRestoreContractTests
         var session = await client.RetrieveSessionAsync();
         session.Should().NotBeNull("an offline client cannot refresh, but must not lose the session");
         this.persistence.DidNotReceive().DestroySession();
-        client.Shutdown();
     }
 
     [TestMethod]
     public void LoadSession_ShouldNotSignOut_GivenAnEmptyStore()
     {
-        var empty = SessionPersistenceSubstitute.Tracking();
-        var client = TestClients.Against(this.server);
-        client.SetPersistence(empty);
+        var client = this.Track(TestClients.Against(this.server));
+        var stateChanges = new List<Constants.AuthState>();
+        client.AddStateChangedListener((_, state) => stateChanges.Add(state));
+        client.SetPersistence(SessionPersistenceSubstitute.Tracking());
         client.LoadSession();
         client.CurrentSession.Should().BeNull();
-        empty.DidNotReceive().DestroySession();
+        stateChanges.Should().NotContain(SignedOut, "a cold start with nothing on either side has no session to sign out of");
     }
 
     [TestMethod]
@@ -98,10 +120,10 @@ public class SessionRestoreContractTests
         var client = TestClients.Against(this.server, autoRefreshToken: true, new HttpClient(handler));
         this.persistence.SaveSession(new Session { AccessToken = "an-access-token", RefreshToken = "a-refresh-token", ExpiresIn = 60, CreatedAt = DateTime.UtcNow.AddHours(-1) });
         this.Restore(client);
-        await Task.Delay(1500);
-        handler.Attempts.Should().BeGreaterThanOrEqualTo(1, "the first attempt for an expired session fires immediately");
-        handler.Attempts.Should().BeLessThan(3, "a failed refresh must back off, not hot-loop");
-        client.Shutdown();
+        await handler.Started;
+        await Task.Delay(250);
+        handler.Attempts.Should().Be(1,
+            "the first attempt for an expired session fires immediately, and a failed one must back off a tick before the next");
     }
 
     [TestMethod]
@@ -116,6 +138,7 @@ public class SessionRestoreContractTests
         handler.Attempts.Should().Be(1, "a refresh token is single-use, so concurrent refreshes must share one attempt");
         await client.RefreshToken();
         handler.Attempts.Should().Be(2, "a completed attempt must not be reused");
+        ((Client) client).refreshAttempt.Should().BeNull("a finished attempt must not keep its refresh token in memory");
     }
 
     [TestMethod]
@@ -124,6 +147,7 @@ public class SessionRestoreContractTests
         var handler = new GatedHandler();
         var client = this.Restore(TestClients.Against(this.server, httpClient: new HttpClient(handler)));
         var refresh = client.RefreshToken();
+        await handler.Started;
         this.persistence.SaveSession(new Session { AccessToken = "another-access-token", RefreshToken = "another-refresh-token", ExpiresIn = 3600 });
         client.LoadSession();
         handler.Release();
@@ -138,13 +162,31 @@ public class SessionRestoreContractTests
         var handler = new GatedHandler();
         var client = this.Restore(TestClients.Against(this.server, httpClient: new HttpClient(handler)));
         var stale = client.RefreshToken();
+        await handler.Started;
         this.persistence.SaveSession(new Session { AccessToken = "another-access-token", RefreshToken = "another-refresh-token", ExpiresIn = 3600 });
         client.LoadSession();
         var fresh = client.RefreshToken();
         handler.Release();
         await Task.WhenAll(stale, fresh);
-        handler.Attempts.Should().Be(2,
+        handler.RefreshTokens.Should().Equal(new[] { "a-refresh-token", "another-refresh-token" },
             "the in-flight attempt holds the previous session's refresh token, so the new session must not join it");
+    }
+
+    [TestMethod]
+    public async Task SignOut_ShouldLeaveNoSessionOrRefreshToken_GivenARefreshInFlight()
+    {
+        var handler = new GatedHandler();
+        var client = this.Restore(TestClients.Against(this.server, httpClient: new HttpClient(handler)));
+        var stateChanges = new List<Constants.AuthState>();
+        client.AddStateChangedListener((_, state) => stateChanges.Add(state));
+        var refresh = client.RefreshToken();
+        await handler.Started;
+        await client.SignOut();
+        handler.Release();
+        await refresh;
+        client.CurrentSession.Should().BeNull("the refresh belonged to the session that was signed out");
+        stateChanges.Should().NotContain(TokenRefreshed);
+        ((Client) client).refreshAttempt.Should().BeNull("the refresh token is a secret and must not outlive the sign-out");
     }
 
     [TestMethod]
@@ -156,7 +198,7 @@ public class SessionRestoreContractTests
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
                 .WithBody(Fixture("token_success.json")));
-        var client = TestClients.Against(this.server);
+        var client = this.Track(TestClients.Against(this.server));
         await client.SignIn("test@example.com", "a-password");
         client.LoadSession();
         client.CurrentSession.Should().NotBeNull("a client with no persistence has nothing to load, so LoadSession must leave it alone");
@@ -168,6 +210,7 @@ public class SessionRestoreContractTests
         var handler = new GatedHandler(HttpStatusCode.BadRequest, "token_not_found_error.json");
         var client = this.Restore(TestClients.Against(this.server, autoRefreshToken: true, new HttpClient(handler)));
         var retrieve = client.RetrieveSessionAsync();
+        await handler.Started;
         this.persistence.SaveSession(new Session { AccessToken = "another-access-token", RefreshToken = "another-refresh-token", ExpiresIn = 3600 });
         client.LoadSession();
         handler.Release();
@@ -194,7 +237,7 @@ public class SessionRestoreContractTests
         for (var i = 0; i < 2; i++)
         {
             var act = () => client.RefreshToken();
-            await act.Should().ThrowAsync<Exception>();
+            await act.Should().ThrowAsync<GotrueException>();
         }
         handler.Attempts.Should().Be(2, "a failed attempt must not be cached as the in-flight refresh");
     }
@@ -204,7 +247,7 @@ public class SessionRestoreContractTests
     {
         var store = Substitute.For<IGotrueSessionPersistence<Session>>();
         store.LoadSession().Returns(_ => throw new IOException("locked"));
-        var client = TestClients.Against(this.server);
+        var client = this.Track(TestClients.Against(this.server));
         client.SetPersistence(store);
         var act = () => client.LoadSession();
         act.Should().NotThrow();
@@ -213,8 +256,15 @@ public class SessionRestoreContractTests
 
     private IGotrueClient<User, Session> Restore(IGotrueClient<User, Session> client)
     {
+        this.Track(client);
         client.SetPersistence(this.persistence);
         client.LoadSession();
+        return client;
+    }
+
+    private IGotrueClient<User, Session> Track(IGotrueClient<User, Session> client)
+    {
+        this.clients.Add(client);
         return client;
     }
 
@@ -223,31 +273,52 @@ public class SessionRestoreContractTests
 
     private sealed class UnreachableHandler : HttpMessageHandler
     {
+        private readonly TaskCompletionSource<bool> started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public int Attempts;
+
+        /// <summary>Completes when the first attempt reaches the handler.</summary>
+        public Task Started => this.started.Task.WaitAsync(HandlerTimeout);
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Interlocked.Increment(ref this.Attempts);
+            this.started.TrySetResult(true);
             throw new HttpRequestException("connection refused");
         }
     }
 
     /// <summary>
-    ///     Answers every request with a successful refresh, but not before the test opens the gate - so a
-    ///     refresh can be held in flight while the test does something to the session behind its back.
+    ///     Answers a token refresh, but not before the test opens the gate - so a refresh can be held in
+    ///     flight while the test does something to the session behind its back. Every other call, sign-out
+    ///     included, is answered straight away.
     /// </summary>
     private sealed class GatedHandler(HttpStatusCode status = HttpStatusCode.OK, string fixture = "token_success.json") : HttpMessageHandler
     {
-        private readonly TaskCompletionSource<bool> gate = new();
+        private readonly TaskCompletionSource<bool> gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ConcurrentQueue<string?> refreshTokens = new();
+        private readonly TaskCompletionSource<bool> started = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public int Attempts;
+        public int Attempts => this.refreshTokens.Count;
+
+        /// <summary>The refresh token each refresh put on the wire, in the order the requests arrived.</summary>
+        public IReadOnlyCollection<string?> RefreshTokens => this.refreshTokens;
+
+        /// <summary>Completes when the first refresh reaches the handler, so a test can act while it is held.</summary>
+        public Task Started => this.started.Task.WaitAsync(HandlerTimeout);
 
         public void Release() => this.gate.TrySetResult(true);
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            Interlocked.Increment(ref this.Attempts);
-            await this.gate.Task;
+            if (!request.RequestUri!.AbsolutePath.EndsWith("/token", StringComparison.Ordinal))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}", Encoding.UTF8, "application/json") };
+            }
+            var body = JsonNode.Parse(await request.Content!.ReadAsStringAsync(cancellationToken))!.AsObject();
+            this.refreshTokens.Enqueue(body["refresh_token"]?.GetValue<string>());
+            this.started.TrySetResult(true);
+            await this.gate.Task.WaitAsync(HandlerTimeout);
             return new HttpResponseMessage(status)
             {
                 Content = new StringContent(Fixture(fixture), Encoding.UTF8, "application/json"),

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -91,6 +91,19 @@ public class SessionRestoreContractTests
         empty.DidNotReceive().DestroySession();
     }
 
+    [TestMethod]
+    public async Task TokenRefresh_ShouldBackOffBetweenAttempts_GivenARestoredExpiredSession()
+    {
+        var handler = new UnreachableHandler();
+        var client = TestClients.Against(this.server, autoRefreshToken: true, new HttpClient(handler));
+        this.persistence.SaveSession(new Session { AccessToken = "an-access-token", RefreshToken = "a-refresh-token", ExpiresIn = 60, CreatedAt = DateTime.UtcNow.AddHours(-1) });
+        this.Restore(client);
+        await Task.Delay(1500);
+        handler.Attempts.Should().BeGreaterThanOrEqualTo(1, "the first attempt for an expired session fires immediately");
+        handler.Attempts.Should().BeLessThan(3, "a failed refresh must back off, not hot-loop");
+        client.Shutdown();
+    }
+
     private IGotrueClient<User, Session> Restore(IGotrueClient<User, Session> client)
     {
         client.SetPersistence(this.persistence);

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -46,7 +46,6 @@ public class SessionRestoreContractTests
         var client = this.Restore(TestClients.Against(this.server, autoRefreshToken: true, new HttpClient(new UnreachableHandler())));
         var session = await client.RetrieveSessionAsync();
         session.Should().NotBeNull("an offline start must not sign the user out");
-        client.CurrentSession.Should().BeSameAs(session);
         this.persistence.DidNotReceive().DestroySession();
         client.Shutdown();
     }
@@ -75,7 +74,6 @@ public class SessionRestoreContractTests
         client.Online = false;
         var session = await client.RetrieveSessionAsync();
         session.Should().NotBeNull("an offline client cannot refresh, but must not lose the session");
-        client.CurrentSession.Should().BeSameAs(session);
         this.persistence.DidNotReceive().DestroySession();
         client.Shutdown();
     }

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -80,6 +80,17 @@ public class SessionRestoreContractTests
         client.Shutdown();
     }
 
+    [TestMethod]
+    public void LoadSession_ShouldNotSignOut_GivenAnEmptyStore()
+    {
+        var empty = SessionPersistenceSubstitute.Tracking();
+        var client = TestClients.Against(this.server);
+        client.SetPersistence(empty);
+        client.LoadSession();
+        client.CurrentSession.Should().BeNull();
+        empty.DidNotReceive().DestroySession();
+    }
+
     private IGotrueClient<User, Session> Restore(IGotrueClient<User, Session> client)
     {
         client.SetPersistence(this.persistence);

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -127,6 +127,20 @@ public class SessionRestoreContractTests
     }
 
     [TestMethod]
+    public async Task TokenRefresh_ShouldRescheduleFromTheRefreshedSession_GivenARefreshOutsideTheTimer()
+    {
+        var handler = new GatedHandler(fixture: "token_success_expiring.json");
+        var client = this.Restore(TestClients.Against(this.server, autoRefreshToken: true, new HttpClient(handler)));
+        handler.Release();
+        await client.RetrieveSessionAsync();
+        var secondAttempt = () => handler.SecondAttempt;
+        await secondAttempt.Should().NotThrowAsync(
+            "the refreshed session expires in a second, so the timer must be rescheduled from it instead of the restored session's deadline an hour out");
+        // Every refresh hands back the same one second session, so stop the timer now the point is made.
+        client.Online = false;
+    }
+
+    [TestMethod]
     public async Task RefreshToken_ShouldShareOneAttempt_GivenConcurrentCallers()
     {
         var handler = new GatedHandler();
@@ -182,11 +196,11 @@ public class SessionRestoreContractTests
         var refresh = client.RefreshToken();
         await handler.Started;
         await client.SignOut();
+        ((Client) client).refreshAttempt.Should().BeNull("the refresh token is a secret and must not outlive the sign-out");
         handler.Release();
         await refresh;
         client.CurrentSession.Should().BeNull("the refresh belonged to the session that was signed out");
         stateChanges.Should().NotContain(TokenRefreshed);
-        ((Client) client).refreshAttempt.Should().BeNull("the refresh token is a secret and must not outlive the sign-out");
     }
 
     [TestMethod]
@@ -202,6 +216,35 @@ public class SessionRestoreContractTests
         await client.SignIn("test@example.com", "a-password");
         client.LoadSession();
         client.CurrentSession.Should().NotBeNull("a client with no persistence has nothing to load, so LoadSession must leave it alone");
+    }
+
+    [TestMethod]
+    public async Task LoadSession_ShouldKeepTheSignedInSession_GivenTheSignInCompletedDuringTheRead()
+    {
+        this.server
+            .Given(Request.Create().WithPath("/token").UsingPost())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(Fixture("token_success.json")));
+        using var readStarted = new ManualResetEventSlim();
+        using var gate = new ManualResetEventSlim();
+        var store = Substitute.For<IGotrueSessionPersistence<Session>>();
+        store.LoadSession().Returns(_ =>
+        {
+            readStarted.Set();
+            gate.Wait(HandlerTimeout);
+            return new Session { AccessToken = "a-stale-access-token", RefreshToken = "a-stale-token", ExpiresIn = 3600 };
+        });
+        var client = this.Track(TestClients.Against(this.server));
+        client.SetPersistence(store);
+        var load = Task.Run(client.LoadSession);
+        readStarted.Wait(HandlerTimeout).Should().BeTrue();
+        await client.SignIn("test@example.com", "a-password");
+        gate.Set();
+        await load;
+        client.CurrentSession!.RefreshToken.Should().Be("new-refresh-token",
+            "the sign-in completed while the store was being read, so the session it produced must not be overwritten by the slower load");
     }
 
     [TestMethod]
@@ -297,6 +340,7 @@ public class SessionRestoreContractTests
     {
         private readonly TaskCompletionSource<bool> gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ConcurrentQueue<string?> refreshTokens = new();
+        private readonly TaskCompletionSource<bool> secondAttempt = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource<bool> started = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public int Attempts => this.refreshTokens.Count;
@@ -306,6 +350,9 @@ public class SessionRestoreContractTests
 
         /// <summary>Completes when the first refresh reaches the handler, so a test can act while it is held.</summary>
         public Task Started => this.started.Task.WaitAsync(HandlerTimeout);
+
+        /// <summary>Completes when a second refresh reaches the handler, so a test can wait for the next scheduled one.</summary>
+        public Task SecondAttempt => this.secondAttempt.Task.WaitAsync(HandlerTimeout);
 
         public void Release() => this.gate.TrySetResult(true);
 
@@ -318,6 +365,10 @@ public class SessionRestoreContractTests
             var body = JsonNode.Parse(await request.Content!.ReadAsStringAsync(cancellationToken))!.AsObject();
             this.refreshTokens.Enqueue(body["refresh_token"]?.GetValue<string>());
             this.started.TrySetResult(true);
+            if (this.refreshTokens.Count >= 2)
+            {
+                this.secondAttempt.TrySetResult(true);
+            }
             await this.gate.Task.WaitAsync(HandlerTimeout, cancellationToken);
             return new HttpResponseMessage(status)
             {

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -105,20 +107,38 @@ public class SessionRestoreContractTests
     [TestMethod]
     public async Task RefreshToken_ShouldShareOneAttempt_GivenConcurrentCallers()
     {
-        this.server
-            .Given(Request.Create().WithPath("/token").UsingPost())
-            .RespondWith(Response.Create()
-                .WithStatusCode(200)
-                .WithHeader("Content-Type", "application/json")
-                .WithBody(Fixture("token_success.json")));
-        var client = this.Restore(TestClients.Against(this.server));
+        var handler = new GatedHandler();
+        var client = this.Restore(TestClients.Against(this.server, httpClient: new HttpClient(handler)));
         var first = client.RefreshToken();
         var second = client.RefreshToken();
-        second.Should().BeSameAs(first, "a refresh token is single-use, so concurrent refreshes must share one attempt");
+        handler.Release();
         await Task.WhenAll(first, second);
-        var third = client.RefreshToken();
-        third.Should().NotBeSameAs(first, "a completed attempt must not be reused");
-        await third;
+        handler.Attempts.Should().Be(1, "a refresh token is single-use, so concurrent refreshes must share one attempt");
+        await client.RefreshToken();
+        handler.Attempts.Should().Be(2, "a completed attempt must not be reused");
+    }
+
+    [TestMethod]
+    public async Task RefreshToken_ShouldDiscardTheResult_GivenTheSessionWasReplacedMidFlight()
+    {
+        var handler = new GatedHandler();
+        var client = this.Restore(TestClients.Against(this.server, httpClient: new HttpClient(handler)));
+        var refresh = client.RefreshToken();
+        this.persistence.SaveSession(new Session { AccessToken = "another-access-token", RefreshToken = "another-refresh-token", ExpiresIn = 3600 });
+        client.LoadSession();
+        handler.Release();
+        await refresh;
+        client.CurrentSession!.RefreshToken.Should().Be("another-refresh-token",
+            "the refresh belonged to the session that was replaced, so its result must not overwrite the new one");
+    }
+
+    [TestMethod]
+    public void LoadSession_ShouldClearTheSession_GivenTheStoreWasEmptied()
+    {
+        var client = this.Restore(TestClients.Against(this.server));
+        this.persistence.DestroySession();
+        client.LoadSession();
+        client.CurrentSession.Should().BeNull("a store emptied behind the client's back must not leave a stale session in memory");
     }
 
     [TestMethod]
@@ -164,6 +184,29 @@ public class SessionRestoreContractTests
         {
             Interlocked.Increment(ref this.Attempts);
             throw new HttpRequestException("connection refused");
+        }
+    }
+
+    /// <summary>
+    ///     Answers every request with a successful refresh, but not before the test opens the gate - so a
+    ///     refresh can be held in flight while the test does something to the session behind its back.
+    /// </summary>
+    private sealed class GatedHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource<bool> gate = new();
+
+        public int Attempts;
+
+        public void Release() => this.gate.TrySetResult(true);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref this.Attempts);
+            await this.gate.Task;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(Fixture("token_success.json"), Encoding.UTF8, "application/json"),
+            };
         }
     }
 }

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -133,6 +133,36 @@ public class SessionRestoreContractTests
     }
 
     [TestMethod]
+    public async Task RefreshToken_ShouldStartItsOwnAttempt_GivenTheSessionWasReplaced()
+    {
+        var handler = new GatedHandler();
+        var client = this.Restore(TestClients.Against(this.server, httpClient: new HttpClient(handler)));
+        var stale = client.RefreshToken();
+        this.persistence.SaveSession(new Session { AccessToken = "another-access-token", RefreshToken = "another-refresh-token", ExpiresIn = 3600 });
+        client.LoadSession();
+        var fresh = client.RefreshToken();
+        handler.Release();
+        await Task.WhenAll(stale, fresh);
+        handler.Attempts.Should().Be(2,
+            "the in-flight attempt holds the previous session's refresh token, so the new session must not join it");
+    }
+
+    [TestMethod]
+    public async Task LoadSession_ShouldKeepTheUserSignedIn_GivenAClientWithoutPersistence()
+    {
+        this.server
+            .Given(Request.Create().WithPath("/token").UsingPost())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(Fixture("token_success.json")));
+        var client = TestClients.Against(this.server);
+        await client.SignIn("test@example.com", "a-password");
+        client.LoadSession();
+        client.CurrentSession.Should().NotBeNull("a client with no persistence has nothing to load, so LoadSession must leave it alone");
+    }
+
+    [TestMethod]
     public void LoadSession_ShouldClearTheSession_GivenTheStoreWasEmptied()
     {
         var client = this.Restore(TestClients.Against(this.server));

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -318,7 +318,7 @@ public class SessionRestoreContractTests
             var body = JsonNode.Parse(await request.Content!.ReadAsStringAsync(cancellationToken))!.AsObject();
             this.refreshTokens.Enqueue(body["refresh_token"]?.GetValue<string>());
             this.started.TrySetResult(true);
-            await this.gate.Task.WaitAsync(HandlerTimeout);
+            await this.gate.Task.WaitAsync(HandlerTimeout, cancellationToken);
             return new HttpResponseMessage(status)
             {
                 Content = new StringContent(Fixture(fixture), Encoding.UTF8, "application/json"),

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -787,9 +787,12 @@ public class Client : IGotrueClient<User, Session>
     /// <inheritdoc />
     public void LoadSession()
     {
-        if (this.sessionPersistence != null)
+        // An empty store is not a sign-out: loading nothing must not clear an
+        // existing session or fire SignedOut (which destroys the persistence).
+        var session = this.sessionPersistence?.Persistence.LoadSession();
+        if (session != null)
         {
-            this.UpdateSession(this.sessionPersistence.Persistence.LoadSession());
+            this.UpdateSession(session);
         }
     }
 

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -57,6 +57,12 @@ public class Client : IGotrueClient<User, Session>
     private Task? refreshInFlight;
 
     /// <summary>
+    ///     The refresh token <see cref="refreshInFlight" /> was started for. A caller holding a different one
+    ///     belongs to another session, so it starts its own attempt.
+    /// </summary>
+    private string? refreshInFlightToken;
+
+    /// <summary>
     ///     Initializes the GoTrue stateful client.
     ///     You will likely want to at least specify a
     ///     <see>
@@ -764,7 +770,8 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        if (this.CurrentSession == null || string.IsNullOrEmpty(this.CurrentSession?.AccessToken) || string.IsNullOrEmpty(this.CurrentSession?.RefreshToken))
+        var session = this.CurrentSession;
+        if (session == null || string.IsNullOrEmpty(session.AccessToken) || string.IsNullOrEmpty(session.RefreshToken))
         {
             throw new GotrueException("No current session.", NoSessionFound);
         }
@@ -772,28 +779,28 @@ public class Client : IGotrueClient<User, Session>
         // Refresh tokens are single-use, and startup can race the auto-refresh timer here - so callers share the in-flight attempt.
         lock (this.refreshGate)
         {
-            if (this.refreshInFlight is not { IsCompleted: false })
+            if (this.refreshInFlight is not { IsCompleted: false } || this.refreshInFlightToken != session.RefreshToken)
             {
-                this.refreshInFlight = this.RefreshCurrentSession();
+                this.refreshInFlightToken = session.RefreshToken;
+                this.refreshInFlight = this.RefreshCurrentSession(session);
             }
             attempt = this.refreshInFlight;
         }
         await attempt;
     }
 
-    private async Task RefreshCurrentSession()
+    private async Task RefreshCurrentSession(Session session)
     {
         using var activity = GotrueInstrumentation.Source.StartActivity(GotrueInstrumentation.Spans.RefreshToken);
-        var refreshToken = this.CurrentSession!.RefreshToken;
         try
         {
-            var result = await this.api.RefreshAccessToken(this.CurrentSession!.AccessToken!, refreshToken!);
+            var result = await this.api.RefreshAccessToken(session.AccessToken!, session.RefreshToken!);
             if (result == null || string.IsNullOrEmpty(result.AccessToken))
             {
                 throw new GotrueException("Could not refresh token from provided session.", NoSessionFound);
             }
             // The session was replaced while this call was in flight, so the result is the previous user's.
-            if (this.CurrentSession?.RefreshToken != refreshToken)
+            if (this.CurrentSession?.RefreshToken != session.RefreshToken)
             {
                 return;
             }
@@ -803,7 +810,7 @@ public class Client : IGotrueClient<User, Session>
         catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken)
         {
             activity.SetFailure(ex);
-            if (this.CurrentSession?.RefreshToken == refreshToken)
+            if (this.CurrentSession?.RefreshToken == session.RefreshToken)
             {
                 this.DestroySession();
                 this.NotifyAuthStateChange(SignedOut);
@@ -821,6 +828,10 @@ public class Client : IGotrueClient<User, Session>
     /// <inheritdoc />
     public void LoadSession()
     {
+        if (this.sessionPersistence == null)
+        {
+            return;
+        }
         Session? session;
         try
         {

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -549,13 +549,13 @@ public class Client : IGotrueClient<User, Session>
             throw new GotrueException("Only supported when online", Offline);
         }
         await this.RefreshToken();
-        if (this.CurrentSession == null)
+        var session = this.CurrentSession;
+        if (session == null)
         {
             throw new GotrueException("Not Logged in.", NoSessionFound);
         }
-        var user = await this.api.GetUser(this.CurrentSession.AccessToken);
-        this.CurrentSession.User = user;
-        return this.CurrentSession;
+        session.User = await this.api.GetUser(session.AccessToken);
+        return session;
     }
 
     /// <inheritdoc />
@@ -1039,6 +1039,11 @@ public class Client : IGotrueClient<User, Session>
     {
         if (session == null)
         {
+            // The refresh token is a secret; clearing the session must not leave it behind.
+            lock (this.refreshGate)
+            {
+                this.refreshInFlightToken = null;
+            }
             this.CurrentSession = null;
             this.NotifyAuthStateChange(SignedOut);
             return;
@@ -1054,12 +1059,5 @@ public class Client : IGotrueClient<User, Session>
     /// <summary>
     ///     Clears the session
     /// </summary>
-    private void DestroySession()
-    {
-        lock (this.refreshGate)
-        {
-            this.refreshInFlightToken = null;
-        }
-        this.UpdateSession(null);
-    }
+    private void DestroySession() => this.UpdateSession(null);
 }

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -792,8 +792,7 @@ public class Client : IGotrueClient<User, Session>
             {
                 throw new GotrueException("Could not refresh token from provided session.", NoSessionFound);
             }
-            // A sign-out, or a sign-in as somebody else, while the call was in flight replaced the session:
-            // this result belongs to the previous user, so drop it rather than resurrect them.
+            // The session was replaced while this call was in flight, so the result is the previous user's.
             if (this.CurrentSession?.RefreshToken != refreshToken)
             {
                 return;

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -47,20 +47,14 @@ public class Client : IGotrueClient<User, Session>
     private IGotruePersistenceListener<Session>? sessionPersistence;
 
     /// <summary>
-    ///     Guards <see cref="refreshInFlight" />.
+    ///     Guards <see cref="refreshAttempt" /> and the writes to <see cref="CurrentSession" />.
     /// </summary>
     private readonly object refreshGate = new();
 
     /// <summary>
     ///     The running token refresh, shared by concurrent callers. A completed attempt is replaced, never reused.
     /// </summary>
-    private Task? refreshInFlight;
-
-    /// <summary>
-    ///     The refresh token <see cref="refreshInFlight" /> was started for. A caller holding a different one
-    ///     belongs to another session, so it starts its own attempt.
-    /// </summary>
-    private string? refreshInFlightToken;
+    internal RefreshAttempt? refreshAttempt;
 
     /// <summary>
     ///     Initializes the GoTrue stateful client.
@@ -80,9 +74,9 @@ public class Client : IGotrueClient<User, Session>
     ///     </see>
     ///     .
     ///     For a typical client application, you'll want to load the session from persistence
-    ///     and then refresh it. If your application is listening for session changes, you'll
-    ///     get two SignIn notifications if the persisted session is valid - one for the
-    ///     session loaded from disk, and a second on a successful session refresh.
+    ///     and then refresh it. If your application is listening for session changes, a valid
+    ///     persisted session raises UserUpdated when it is loaded from disk, and TokenRefreshed
+    ///     once the refresh succeeds - neither step raises SignedIn.
     ///     <remarks></remarks>
     ///     <example>
     ///         var client = new Supabase.Gotrue.Client(options);
@@ -774,47 +768,75 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        var session = this.CurrentSession;
-        if (session == null || string.IsNullOrEmpty(session.AccessToken) || string.IsNullOrEmpty(session.RefreshToken))
-        {
-            throw new GotrueException("No current session.", NoSessionFound);
-        }
         Task attempt;
         // Refresh tokens are single-use, and startup can race the auto-refresh timer here - so callers share the in-flight attempt.
+        // The session is read and the attempt registered under one hold of the gate, so a sign-out cannot interleave.
         lock (this.refreshGate)
         {
-            if (this.refreshInFlight is not { IsCompleted: false } || this.refreshInFlightToken != session.RefreshToken)
+            var session = this.CurrentSession;
+            if (session == null || string.IsNullOrEmpty(session.AccessToken) || string.IsNullOrEmpty(session.RefreshToken))
             {
-                this.refreshInFlightToken = session.RefreshToken;
-                this.refreshInFlight = this.RefreshCurrentSession(session);
+                throw new GotrueException("No current session.", NoSessionFound);
             }
-            attempt = this.refreshInFlight;
+            if (this.refreshAttempt is { Refresh.IsCompleted: false } current && current.Token == session.RefreshToken)
+            {
+                attempt = current.Refresh;
+            }
+            else
+            {
+                attempt = this.RefreshCurrentSession(session.AccessToken!, session.RefreshToken!);
+                this.refreshAttempt = new RefreshAttempt(session.RefreshToken!, attempt);
+            }
         }
-        await attempt;
+        try
+        {
+            await attempt;
+        }
+        finally
+        {
+            // Only this attempt's own registration is cleared, so a later attempt is never deregistered.
+            lock (this.refreshGate)
+            {
+                if (ReferenceEquals(this.refreshAttempt?.Refresh, attempt))
+                {
+                    this.refreshAttempt = null;
+                }
+            }
+        }
     }
 
-    private async Task RefreshCurrentSession(Session session)
+    private async Task RefreshCurrentSession(string accessToken, string refreshToken)
     {
+        // The refresh gate is held while this method starts, and app code must never run under it.
+        await Task.Yield();
         using var activity = GotrueInstrumentation.Source.StartActivity(GotrueInstrumentation.Spans.RefreshToken);
         try
         {
-            var result = await this.api.RefreshAccessToken(session.AccessToken!, session.RefreshToken!);
+            var result = await this.api.RefreshAccessToken(accessToken, refreshToken);
             if (result == null || string.IsNullOrEmpty(result.AccessToken))
             {
                 throw new GotrueException("Could not refresh token from provided session.", NoSessionFound);
             }
-            // The session was replaced while this call was in flight, so the result is the previous user's.
-            if (this.CurrentSession?.RefreshToken != session.RefreshToken)
+            lock (this.refreshGate)
             {
-                return;
+                // The session was replaced while this call was in flight, so the result is the previous user's.
+                if (this.CurrentSession?.RefreshToken != refreshToken)
+                {
+                    return;
+                }
+                this.CurrentSession = result;
             }
-            this.CurrentSession = result;
             this.NotifyAuthStateChange(TokenRefreshed);
         }
         catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken)
         {
             activity.SetFailure(ex);
-            if (this.CurrentSession?.RefreshToken == session.RefreshToken)
+            bool stillOurs;
+            lock (this.refreshGate)
+            {
+                stillOurs = this.CurrentSession?.RefreshToken == refreshToken;
+            }
+            if (stillOurs)
             {
                 this.DestroySession();
                 this.NotifyAuthStateChange(SignedOut);
@@ -1037,19 +1059,22 @@ public class Client : IGotrueClient<User, Session>
     /// <param name="session"></param>
     private void UpdateSession(Session? session)
     {
+        bool dirty;
+        lock (this.refreshGate)
+        {
+            dirty = this.CurrentSession != session;
+            this.CurrentSession = session;
+            if (session == null)
+            {
+                // The session and the in-flight attempt clear together, so a concurrent RefreshToken cannot see one without the other.
+                this.refreshAttempt = null;
+            }
+        }
         if (session == null)
         {
-            // The refresh token is a secret; clearing the session must not leave it behind.
-            lock (this.refreshGate)
-            {
-                this.refreshInFlightToken = null;
-            }
-            this.CurrentSession = null;
             this.NotifyAuthStateChange(SignedOut);
             return;
         }
-        var dirty = this.CurrentSession != session;
-        this.CurrentSession = session;
         if (dirty)
         {
             this.NotifyAuthStateChange(UserUpdated);
@@ -1060,4 +1085,15 @@ public class Client : IGotrueClient<User, Session>
     ///     Clears the session
     /// </summary>
     private void DestroySession() => this.UpdateSession(null);
+
+    /// <summary>
+    ///     A token refresh in flight, with the refresh token it was started for. A caller holding a different
+    ///     one belongs to another session, so it starts its own attempt instead of joining this one.
+    /// </summary>
+    internal readonly struct RefreshAttempt(string token, Task refresh)
+    {
+        internal string Token { get; } = token;
+
+        internal Task Refresh { get; } = refresh;
+    }
 }

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -670,7 +670,7 @@ public class Client : IGotrueClient<User, Session>
                 await this.RefreshToken();
                 return this.CurrentSession;
             }
-            catch (GotrueException e) when (e.Reason is InvalidRefreshToken or ExpiredRefreshToken)
+            catch (GotrueException e) when (e.Reason is InvalidRefreshToken)
             {
                 // RefreshToken already destroyed the session.
                 activity.SetFailure(e);
@@ -743,7 +743,7 @@ public class Client : IGotrueClient<User, Session>
             this.CurrentSession = result;
             this.NotifyAuthStateChange(TokenRefreshed);
         }
-        catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken or ExpiredRefreshToken)
+        catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken)
         {
             activity.SetFailure(ex);
             this.DestroySession();
@@ -758,7 +758,7 @@ public class Client : IGotrueClient<User, Session>
     }
 
     /// <inheritdoc />
-    public Task RefreshToken()
+    public async Task RefreshToken()
     {
         if (!this.Online)
         {
@@ -768,6 +768,7 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("No current session.", NoSessionFound);
         }
+        Task attempt;
         // Refresh tokens are single-use, and startup can race the auto-refresh timer here - so callers share the in-flight attempt.
         lock (this.refreshGate)
         {
@@ -775,28 +776,39 @@ public class Client : IGotrueClient<User, Session>
             {
                 this.refreshInFlight = this.RefreshCurrentSession();
             }
-            return this.refreshInFlight;
+            attempt = this.refreshInFlight;
         }
+        await attempt;
     }
 
     private async Task RefreshCurrentSession()
     {
         using var activity = GotrueInstrumentation.Source.StartActivity(GotrueInstrumentation.Spans.RefreshToken);
+        var refreshToken = this.CurrentSession!.RefreshToken;
         try
         {
-            var result = await this.api.RefreshAccessToken(this.CurrentSession!.AccessToken!, this.CurrentSession.RefreshToken!);
+            var result = await this.api.RefreshAccessToken(this.CurrentSession!.AccessToken!, refreshToken!);
             if (result == null || string.IsNullOrEmpty(result.AccessToken))
             {
                 throw new GotrueException("Could not refresh token from provided session.", NoSessionFound);
             }
+            // A sign-out, or a sign-in as somebody else, while the call was in flight replaced the session:
+            // this result belongs to the previous user, so drop it rather than resurrect them.
+            if (this.CurrentSession?.RefreshToken != refreshToken)
+            {
+                return;
+            }
             this.CurrentSession = result;
             this.NotifyAuthStateChange(TokenRefreshed);
         }
-        catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken or ExpiredRefreshToken)
+        catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken)
         {
             activity.SetFailure(ex);
-            this.DestroySession();
-            this.NotifyAuthStateChange(SignedOut);
+            if (this.CurrentSession?.RefreshToken == refreshToken)
+            {
+                this.DestroySession();
+                this.NotifyAuthStateChange(SignedOut);
+            }
             throw;
         }
         catch (Exception ex)
@@ -821,9 +833,9 @@ public class Client : IGotrueClient<User, Session>
             this.debugNotification?.Log($"Failed to load the persisted session ({e.Message})", e);
             return;
         }
-        // An empty store is not a sign-out: loading nothing must not clear an
-        // existing session or fire SignedOut (which destroys the persistence).
-        if (session != null)
+        // An emptied store clears the session it was holding, but a cold start with nothing on either
+        // side is a no-op: firing SignedOut there would destroy the persistence.
+        if (session != null || this.CurrentSession != null)
         {
             this.UpdateSession(session);
         }

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -47,6 +47,16 @@ public class Client : IGotrueClient<User, Session>
     private IGotruePersistenceListener<Session>? sessionPersistence;
 
     /// <summary>
+    ///     Guards <see cref="refreshInFlight" />.
+    /// </summary>
+    private readonly object refreshGate = new();
+
+    /// <summary>
+    ///     The running token refresh, shared by concurrent callers. A completed attempt is replaced, never reused.
+    /// </summary>
+    private Task? refreshInFlight;
+
+    /// <summary>
     ///     Initializes the GoTrue stateful client.
     ///     You will likely want to at least specify a
     ///     <see>
@@ -748,9 +758,8 @@ public class Client : IGotrueClient<User, Session>
     }
 
     /// <inheritdoc />
-    public async Task RefreshToken()
+    public Task RefreshToken()
     {
-        using var activity = GotrueInstrumentation.Source.StartActivity(GotrueInstrumentation.Spans.RefreshToken);
         if (!this.Online)
         {
             throw new GotrueException("Only supported when online", Offline);
@@ -759,9 +768,24 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("No current session.", NoSessionFound);
         }
+        // The startup path and the auto-refresh timer can land here together, and a
+        // refresh token is single-use - concurrent calls share the running attempt.
+        lock (this.refreshGate)
+        {
+            if (this.refreshInFlight is not { IsCompleted: false })
+            {
+                this.refreshInFlight = this.RefreshCurrentSession();
+            }
+            return this.refreshInFlight;
+        }
+    }
+
+    private async Task RefreshCurrentSession()
+    {
+        using var activity = GotrueInstrumentation.Source.StartActivity(GotrueInstrumentation.Spans.RefreshToken);
         try
         {
-            var result = await this.api.RefreshAccessToken(this.CurrentSession.AccessToken!, this.CurrentSession.RefreshToken!);
+            var result = await this.api.RefreshAccessToken(this.CurrentSession!.AccessToken!, this.CurrentSession.RefreshToken!);
             if (result == null || string.IsNullOrEmpty(result.AccessToken))
             {
                 throw new GotrueException("Could not refresh token from provided session.", NoSessionFound);
@@ -787,9 +811,19 @@ public class Client : IGotrueClient<User, Session>
     /// <inheritdoc />
     public void LoadSession()
     {
+        Session? session;
+        try
+        {
+            session = this.sessionPersistence?.Persistence.LoadSession();
+        }
+        catch (Exception e)
+        {
+            // A store that fails to load (locked file, corrupt payload) must not crash startup.
+            this.debugNotification?.Log($"Failed to load the persisted session ({e.Message})", e);
+            return;
+        }
         // An empty store is not a sign-out: loading nothing must not clear an
         // existing session or fire SignedOut (which destroys the persistence).
-        var session = this.sessionPersistence?.Persistence.LoadSession();
         if (session != null)
         {
             this.UpdateSession(session);

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -768,8 +768,7 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("No current session.", NoSessionFound);
         }
-        // The startup path and the auto-refresh timer can land here together, and a
-        // refresh token is single-use - concurrent calls share the running attempt.
+        // Refresh tokens are single-use, and startup can race the auto-refresh timer here - so callers share the in-flight attempt.
         lock (this.refreshGate)
         {
             if (this.refreshInFlight is not { IsCompleted: false })

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -646,10 +646,10 @@ public class Client : IGotrueClient<User, Session>
             return null;
         }
 
-        // If we aren't online, we can't refresh the token
+        // We can't refresh the token offline, so return the session as loaded.
         if (!this.Online)
         {
-            throw new GotrueException("Only supported when online", Offline);
+            return this.CurrentSession;
         }
 
         // We have a session, and hasn't expired, and we seem to be online. Let's try to refresh it.
@@ -660,14 +660,19 @@ public class Client : IGotrueClient<User, Session>
                 await this.RefreshToken();
                 return this.CurrentSession;
             }
+            catch (GotrueException e) when (e.Reason is InvalidRefreshToken or ExpiredRefreshToken)
+            {
+                // RefreshToken already destroyed the session.
+                activity.SetFailure(e);
+                return null;
+            }
             catch (Exception e)
             {
+                // Anything else is treated as transient - keep the session so the next refresh can retry.
                 // Never log the session itself here - it contains the access and refresh tokens.
                 this.debugNotification?.Log($"Failed to refresh token ({e.Message})", e);
-                this.debugNotification?.Log($"Destroying session created at {this.CurrentSession?.CreatedAt:O} (expires in {this.CurrentSession?.ExpiresIn}s) that could not be refreshed");
                 activity.SetFailure(e);
-                this.DestroySession();
-                return null;
+                return this.CurrentSession;
             }
         }
         return this.CurrentSession;
@@ -728,7 +733,7 @@ public class Client : IGotrueClient<User, Session>
             this.CurrentSession = result;
             this.NotifyAuthStateChange(TokenRefreshed);
         }
-        catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken)
+        catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken or ExpiredRefreshToken)
         {
             activity.SetFailure(ex);
             this.DestroySession();
@@ -764,7 +769,7 @@ public class Client : IGotrueClient<User, Session>
             this.CurrentSession = result;
             this.NotifyAuthStateChange(TokenRefreshed);
         }
-        catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken)
+        catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken or ExpiredRefreshToken)
         {
             activity.SetFailure(ex);
             this.DestroySession();

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -549,6 +549,10 @@ public class Client : IGotrueClient<User, Session>
             throw new GotrueException("Only supported when online", Offline);
         }
         await this.RefreshToken();
+        if (this.CurrentSession == null)
+        {
+            throw new GotrueException("Not Logged in.", NoSessionFound);
+        }
         var user = await this.api.GetUser(this.CurrentSession.AccessToken);
         this.CurrentSession.User = user;
         return this.CurrentSession;
@@ -678,9 +682,9 @@ public class Client : IGotrueClient<User, Session>
             }
             catch (GotrueException e) when (e.Reason is InvalidRefreshToken)
             {
-                // RefreshToken already destroyed the session.
+                // RefreshToken destroyed the session, unless it was replaced mid-flight.
                 activity.SetFailure(e);
-                return null;
+                return this.CurrentSession;
             }
             catch (Exception e)
             {
@@ -835,7 +839,7 @@ public class Client : IGotrueClient<User, Session>
         Session? session;
         try
         {
-            session = this.sessionPersistence?.Persistence.LoadSession();
+            session = this.sessionPersistence.Persistence.LoadSession();
         }
         catch (Exception e)
         {
@@ -1050,5 +1054,12 @@ public class Client : IGotrueClient<User, Session>
     /// <summary>
     ///     Clears the session
     /// </summary>
-    private void DestroySession() => this.UpdateSession(null);
+    private void DestroySession()
+    {
+        lock (this.refreshGate)
+        {
+            this.refreshInFlightToken = null;
+        }
+        this.UpdateSession(null);
+    }
 }

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -858,6 +858,7 @@ public class Client : IGotrueClient<User, Session>
         {
             return;
         }
+        var before = this.CurrentSession;
         Session? session;
         try
         {
@@ -871,7 +872,8 @@ public class Client : IGotrueClient<User, Session>
         }
         // An emptied store clears the session it was holding, but a cold start with nothing on either
         // side is a no-op: firing SignedOut there would destroy the persistence.
-        if (session != null || this.CurrentSession != null)
+        // A sign-in that completed while the store was being read wins over what the read came back with.
+        if ((session != null || before != null) && ReferenceEquals(this.CurrentSession, before))
         {
             this.UpdateSession(session);
         }

--- a/packages/Gotrue/Gotrue/Gotrue.csproj
+++ b/packages/Gotrue/Gotrue/Gotrue.csproj
@@ -54,4 +54,7 @@
         <None Remove="Exceptions\" />
         <None Include="..\README.md" Pack="true" PackagePath="\" Visible="false" />
     </ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="Gotrue.Tests" />
+    </ItemGroup>
 </Project>

--- a/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
+++ b/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
@@ -468,8 +468,8 @@ namespace Supabase.Gotrue.Interfaces
         void AddDebugListener(Action<string, Exception?> listener);
 
         /// <summary>
-        ///     Loads the session from the persistence layer. An empty or failing store is a no-op:
-        ///     it never clears an existing session or signs the user out.
+        ///     Loads the session from the persistence layer. An empty store clears the current
+        ///     session; a store that fails to load is ignored.
         /// </summary>
         void LoadSession();
 

--- a/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
+++ b/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
@@ -129,8 +129,10 @@ namespace Supabase.Gotrue.Interfaces
         /// <summary>
         ///     Typically called as part of the startup process for the client.
         ///     This will take the currently loaded session (e.g. from a persistence implementation) and
-        ///     if possible attempt to refresh it. If the loaded session is expired or invalid, it will
-        ///     log the user out.
+        ///     if possible attempt to refresh it. The user is logged out only when the server rejects
+        ///     the refresh token as invalid; any other failure keeps the session, so a returned session
+        ///     is not a guarantee that its access token is still valid. When the client is marked
+        ///     offline the session is returned without a refresh attempt.
         /// </summary>
         /// <returns></returns>
         Task<TSession?> RetrieveSessionAsync();

--- a/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
+++ b/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
@@ -468,7 +468,8 @@ namespace Supabase.Gotrue.Interfaces
         void AddDebugListener(Action<string, Exception?> listener);
 
         /// <summary>
-        ///     Loads the session from the persistence layer.
+        ///     Loads the session from the persistence layer. An empty or failing store is a no-op:
+        ///     it never clears an existing session or signs the user out.
         /// </summary>
         void LoadSession();
 

--- a/packages/Gotrue/Gotrue/TokenRefresh.cs
+++ b/packages/Gotrue/Gotrue/TokenRefresh.cs
@@ -66,12 +66,12 @@ namespace Supabase.Gotrue
 					// Turn off auto-refresh timer
 					break;
 				case UserUpdated:
+				case TokenRefreshed:
 					if (Debug)
 						_client.Debug("Refresh Timer restarted");
 					CreateNewTimer();
 					break;
 				case PasswordRecovery:
-				case TokenRefreshed:
 				case MfaChallengeVerified:
 					// Doesn't affect auto refresh
 					break;

--- a/packages/Gotrue/Gotrue/TokenRefresh.cs
+++ b/packages/Gotrue/Gotrue/TokenRefresh.cs
@@ -16,8 +16,10 @@ namespace Supabase.Gotrue
 
 		/// <summary>
 		/// Minimum wait between refresh attempts after one was skipped or failed.
+		/// supabase-js polls on a fixed 30 second tick (AUTO_REFRESH_TICK_DURATION_MS) and
+		/// picks a failed refresh up on the next one, so a failed attempt waits one tick too.
 		/// </summary>
-		private static readonly TimeSpan FailedRefreshRetryFloor = TimeSpan.FromSeconds(30);
+		private static readonly TimeSpan AutoRefreshTickDuration = TimeSpan.FromSeconds(30);
 
 		/// <summary>
 		/// Internal timer reference for token refresh
@@ -102,8 +104,8 @@ namespace Supabase.Gotrue
 			finally
 			{
 				// An expired session schedules at zero, so a refresh that was skipped or
-				// failed must wait before the next attempt instead of hot-looping.
-				CreateNewTimer(refreshed ? TimeSpan.Zero : FailedRefreshRetryFloor);
+				// failed must wait a tick before the next attempt instead of hot-looping.
+				CreateNewTimer(refreshed ? TimeSpan.Zero : AutoRefreshTickDuration);
 			}
 		}
 

--- a/packages/Gotrue/Gotrue/TokenRefresh.cs
+++ b/packages/Gotrue/Gotrue/TokenRefresh.cs
@@ -15,6 +15,11 @@ namespace Supabase.Gotrue
 		private readonly Client _client;
 
 		/// <summary>
+		/// Minimum wait between refresh attempts after one was skipped or failed.
+		/// </summary>
+		private static readonly TimeSpan FailedRefreshRetryFloor = TimeSpan.FromSeconds(30);
+
+		/// <summary>
 		/// Internal timer reference for token refresh
 		/// <see>
 		///     <cref>AutoRefreshToken</cref>
@@ -79,10 +84,14 @@ namespace Supabase.Gotrue
 		/// </summary>
 		private async void HandleRefreshTimerTick(object _)
 		{
+			var refreshed = false;
 			try
 			{
 				if (_client.Online)
+				{
 					await _client.RefreshToken();
+					refreshed = true;
+				}
 			}
 			catch (Exception ex)
 			{
@@ -92,7 +101,9 @@ namespace Supabase.Gotrue
 			}
 			finally
 			{
-				CreateNewTimer();
+				// An expired session schedules at zero, so a refresh that was skipped or
+				// failed must wait before the next attempt instead of hot-looping.
+				CreateNewTimer(refreshed ? TimeSpan.Zero : FailedRefreshRetryFloor);
 			}
 		}
 
@@ -103,9 +114,9 @@ namespace Supabase.Gotrue
 		/// We pass <see cref="Timeout.InfiniteTimeSpan"/> to ensure the handler only runs once.
 		/// We create a new timer after each refresh so that each refresh runs in a new thread.
 		/// This keeps the refresh going if a thread crashes.
-		/// Creating a thread each refresh is not so expensive when the refresh interval is an hour or longer.
+		/// Creating a thread each refresh is not so expensive at this cadence - at worst one every 30 seconds while refreshes keep failing.
 		/// </summary>
-		private void CreateNewTimer()
+		private void CreateNewTimer(TimeSpan floor = default)
 		{
 			if (_client.CurrentSession == null)
 			{
@@ -117,6 +128,8 @@ namespace Supabase.Gotrue
 			try
 			{
 				TimeSpan refreshDueTime = GetSecondsUntilNextRefresh();
+				if (refreshDueTime < floor)
+					refreshDueTime = floor;
 				_refreshTimer?.Dispose();
 				_refreshTimer = new Timer(HandleRefreshTimerTick, null, refreshDueTime, Timeout.InfiniteTimeSpan);
 

--- a/packages/Gotrue/Gotrue/TokenRefresh.cs
+++ b/packages/Gotrue/Gotrue/TokenRefresh.cs
@@ -86,13 +86,13 @@ namespace Supabase.Gotrue
 		/// </summary>
 		private async void HandleRefreshTimerTick(object _)
 		{
-			var refreshed = false;
+			var refreshCompleted = false;
 			try
 			{
 				if (_client.Online)
 				{
 					await _client.RefreshToken();
-					refreshed = true;
+					refreshCompleted = true;
 				}
 			}
 			catch (Exception ex)
@@ -105,7 +105,7 @@ namespace Supabase.Gotrue
 			{
 				// An expired session schedules at zero, so a refresh that was skipped or
 				// failed must wait a tick before the next attempt instead of hot-looping.
-				CreateNewTimer(refreshed ? TimeSpan.Zero : AutoRefreshTickDuration);
+				CreateNewTimer(refreshCompleted ? TimeSpan.Zero : AutoRefreshTickDuration);
 			}
 		}
 
@@ -114,11 +114,11 @@ namespace Supabase.Gotrue
 		/// 
 		/// <para/>
 		/// We pass <see cref="Timeout.InfiniteTimeSpan"/> to ensure the handler only runs once.
-		/// We create a new timer after each refresh so that each refresh runs in a new thread.
-		/// This keeps the refresh going if a thread crashes.
-		/// Creating a thread each refresh is not so expensive at this cadence - at worst one every 30 seconds while refreshes keep failing.
+		/// We create a new timer after each refresh instead of a repeating one, so the next tick is
+		/// scheduled from the session we ended up with rather than from a fixed interval.
+		/// The callbacks run on the thread pool, so a timer per refresh is cheap at this cadence.
 		/// </summary>
-		private void CreateNewTimer(TimeSpan floor = default)
+		private void CreateNewTimer(TimeSpan minimumDelay = default)
 		{
 			if (_client.CurrentSession == null)
 			{
@@ -130,8 +130,8 @@ namespace Supabase.Gotrue
 			try
 			{
 				TimeSpan refreshDueTime = GetSecondsUntilNextRefresh();
-				if (refreshDueTime < floor)
-					refreshDueTime = floor;
+				if (refreshDueTime < minimumDelay)
+					refreshDueTime = minimumDelay;
 				_refreshTimer?.Dispose();
 				_refreshTimer = new Timer(HandleRefreshTimerTick, null, refreshDueTime, Timeout.InfiniteTimeSpan);
 

--- a/packages/Supabase/Supabase.Tests/SupabaseClientCompositionTests.cs
+++ b/packages/Supabase/Supabase.Tests/SupabaseClientCompositionTests.cs
@@ -220,6 +220,15 @@ public class SupabaseClientCompositionTests
     }
 
     [TestMethod]
+    public async Task SupabaseClient_ShouldNotReloadTheSession_GivenOneAlreadySet()
+    {
+        var auth = Substitute.For<IGotrueClient<User, Session>>();
+        auth.CurrentSession.Returns(new Session { AccessToken = "an-access-token", RefreshToken = "a-refresh-token" });
+        await DiClient(auth: auth).InitializeAsync();
+        auth.DidNotReceive().LoadSession();
+    }
+
+    [TestMethod]
     public async Task SupabaseClient_ShouldKeepThePersistedSession_GivenAnOfflineStart()
     {
         var persistence = Substitute.For<IGotrueSessionPersistence<Session>>();

--- a/packages/Supabase/Supabase.Tests/SupabaseClientCompositionTests.cs
+++ b/packages/Supabase/Supabase.Tests/SupabaseClientCompositionTests.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Net.Http;
 using System.Net.WebSockets;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -233,8 +235,13 @@ public class SupabaseClientCompositionTests
     {
         var persistence = Substitute.For<IGotrueSessionPersistence<Session>>();
         persistence.LoadSession().Returns(new Session { AccessToken = "an-access-token", RefreshToken = "a-refresh-token", ExpiresIn = 3600 });
-        var client = new Supabase.Client("http://localhost:1", "a-key",
-            new SupabaseOptions { AutoConnectRealtime = false, SessionHandler = persistence });
+        var client = new Supabase.Client("http://localhost", "a-key",
+            new SupabaseOptions
+            {
+                AutoConnectRealtime = false,
+                SessionHandler = persistence,
+                HttpClient = new HttpClient(new UnreachableHandler()),
+            });
         await client.InitializeAsync();
         client.Auth.CurrentSession.Should().NotBeNull("an unreachable auth server must not sign the user out");
         persistence.DidNotReceive().DestroySession();
@@ -329,5 +336,11 @@ public class SupabaseClientCompositionTests
         var client = DiClient(realtime: previous);
         client.Realtime = Substitute.For<IRealtimeClient<RealtimeSocket, RealtimeChannel>>();
         previous.Received().Disconnect(Arg.Any<WebSocketCloseStatus>(), Arg.Any<string>());
+    }
+
+    private sealed class UnreachableHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw new HttpRequestException("connection refused");
     }
 }

--- a/packages/Supabase/Supabase.Tests/SupabaseClientCompositionTests.cs
+++ b/packages/Supabase/Supabase.Tests/SupabaseClientCompositionTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
-using Supabase;
 using Supabase.Functions.Interfaces;
 using Supabase.Gotrue;
 using Supabase.Gotrue.Interfaces;
@@ -32,16 +31,16 @@ namespace Supabase.Tests;
 [TestCategory("Unit")]
 public class SupabaseClientCompositionTests
 {
-    private static Supabase.Client UrlClient(SupabaseOptions options = null) =>
+    private static Supabase.Client UrlClient(SupabaseOptions? options = null) =>
         new("http://localhost", "test-key", options ?? new SupabaseOptions { AutoConnectRealtime = false });
 
     // Builds the umbrella through its DI constructor with substituted children; a test overrides only
     // the collaborator it cares about.
     private static Supabase.Client DiClient(
-        IGotrueClient<User, Session> auth = null,
-        IRealtimeClient<RealtimeSocket, RealtimeChannel> realtime = null,
-        IPostgrestClient postgrest = null,
-        SupabaseOptions options = null) =>
+        IGotrueClient<User, Session>? auth = null,
+        IRealtimeClient<RealtimeSocket, RealtimeChannel>? realtime = null,
+        IPostgrestClient? postgrest = null,
+        SupabaseOptions? options = null) =>
         new(auth ?? Substitute.For<IGotrueClient<User, Session>>(),
             realtime ?? RealtimeSubstitute(),
             Substitute.For<IFunctionsClient>(),
@@ -169,7 +168,7 @@ public class SupabaseClientCompositionTests
         var auth = Substitute.For<IGotrueClient<User, Session>>();
         auth.CurrentSession.Returns(new Session { AccessToken = "signed-in-token" });
         var client = DiClient(realtime: realtime);
-        IGotrueClient<User, Session>.AuthEventHandler captured = null;
+        IGotrueClient<User, Session>.AuthEventHandler? captured = null;
         auth.When(a => a.AddStateChangedListener(Arg.Any<IGotrueClient<User, Session>.AuthEventHandler>()))
             .Do(call => captured = call.Arg<IGotrueClient<User, Session>.AuthEventHandler>());
         client.Auth = auth;
@@ -188,7 +187,7 @@ public class SupabaseClientCompositionTests
             new Dictionary<string, RealtimeChannel>()));
         var auth = Substitute.For<IGotrueClient<User, Session>>();
         var client = DiClient(realtime: realtime);
-        IGotrueClient<User, Session>.AuthEventHandler captured = null;
+        IGotrueClient<User, Session>.AuthEventHandler? captured = null;
         auth.When(a => a.AddStateChangedListener(Arg.Any<IGotrueClient<User, Session>.AuthEventHandler>()))
             .Do(call => captured = call.Arg<IGotrueClient<User, Session>.AuthEventHandler>());
         client.Auth = auth;
@@ -206,6 +205,31 @@ public class SupabaseClientCompositionTests
         await client.InitializeAsync();
         await auth.Received().RetrieveSessionAsync();
         await realtime.Received().ConnectAsync();
+    }
+
+    [TestMethod]
+    public async Task SupabaseClient_ShouldRestoreThePersistedSessionBeforeRefreshingIt_GivenInitialize()
+    {
+        var auth = Substitute.For<IGotrueClient<User, Session>>();
+        await DiClient(auth: auth).InitializeAsync();
+        Received.InOrder(() =>
+        {
+            auth.LoadSession();
+            auth.RetrieveSessionAsync();
+        });
+    }
+
+    [TestMethod]
+    public async Task SupabaseClient_ShouldKeepThePersistedSession_GivenAnOfflineStart()
+    {
+        var persistence = Substitute.For<IGotrueSessionPersistence<Session>>();
+        persistence.LoadSession().Returns(new Session { AccessToken = "an-access-token", RefreshToken = "a-refresh-token", ExpiresIn = 3600 });
+        var client = new Supabase.Client("http://localhost:1", "a-key",
+            new SupabaseOptions { AutoConnectRealtime = false, SessionHandler = persistence });
+        await client.InitializeAsync();
+        client.Auth.CurrentSession.Should().NotBeNull("an unreachable auth server must not sign the user out");
+        persistence.DidNotReceive().DestroySession();
+        client.Auth.Shutdown();
     }
 
     [TestMethod]
@@ -266,10 +290,7 @@ public class SupabaseClientCompositionTests
     }
 
     [TestMethod]
-    public void SupabaseClient_ShouldExposeAdminAuthClient_GivenServiceKey()
-    {
-        UrlClient().AdminAuth("service-key").Should().NotBeNull();
-    }
+    public void SupabaseClient_ShouldExposeAdminAuthClient_GivenServiceKey() => UrlClient().AdminAuth("service-key").Should().NotBeNull();
 
     [TestMethod]
     public void SupabaseClient_ShouldPreferSessionTokenOverApiKey_GivenActiveSession()

--- a/packages/Supabase/Supabase/Client.cs
+++ b/packages/Supabase/Supabase/Client.cs
@@ -217,6 +217,7 @@ public class Client : ISupabaseClient<User, Session, RealtimeSocket, RealtimeCha
     public async Task<ISupabaseClient<User, Session, RealtimeSocket, RealtimeChannel, Bucket, FileObject>>
         InitializeAsync()
     {
+        // Don't clobber a session already set by the caller with a stale one from disk.
         if (this.Auth.CurrentSession == null)
             this.Auth.LoadSession();
         await this.Auth.RetrieveSessionAsync();

--- a/packages/Supabase/Supabase/Client.cs
+++ b/packages/Supabase/Supabase/Client.cs
@@ -212,11 +212,13 @@ public class Client : ISupabaseClient<User, Session, RealtimeSocket, RealtimeCha
 
 
     /// <summary>
-    /// Attempts to retrieve the session from Gotrue (set in <see cref="SupabaseOptions"/>) and connects to realtime (if `options.AutoConnectRealtime` is set)
+    /// Restores the session persisted by <see cref="SupabaseOptions.SessionHandler"/>, refreshes it, and connects to realtime (if `options.AutoConnectRealtime` is set)
     /// </summary>
     public async Task<ISupabaseClient<User, Session, RealtimeSocket, RealtimeChannel, Bucket, FileObject>>
         InitializeAsync()
     {
+        if (this.Auth.CurrentSession == null)
+            this.Auth.LoadSession();
         await this.Auth.RetrieveSessionAsync();
 
         if (this.options.AutoConnectRealtime)


### PR DESCRIPTION
Fixes #390

gotrue: a failed refresh destroyed the session even on a plain network error, so an offline start signed the user out for good. Now only a server-rejected refresh token signs out, same as supabase-js. While in there: an empty session store no longer fires a spurious SignedOut, a failed refresh waits one 30s tick instead of hot-looping (the supabase-js cadence), concurrent refreshes share one attempt and a refresh that finishes after the session was replaced is discarded instead of clobbering it, and a store that throws on load doesn't crash startup.

supabase: InitializeAsync now restores the persisted session, like the readme always said.
