### PR TITLE
fix(gotrue): keep sessions the sign-in and refresh paths do not own

### DIFF
--- a/packages/Gotrue/Gotrue.Tests/Authentication/AuthenticationFailureTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Authentication/AuthenticationFailureTests.cs
@@ -18,8 +18,7 @@ namespace Gotrue.Tests.Authentication;
 
 /// <summary>
 ///     End-to-end sign-up / sign-in rejections against the live stack: each invalid credential surfaces the
-///     matching <see cref="FailureHint.Reason" />, leaves nothing persisted, and reports a single signed-out
-///     state change.
+///     matching <see cref="FailureHint.Reason" /> and leaves the current session alone.
 /// </summary>
 [TestClass]
 [TestCategory("E2E")]
@@ -29,14 +28,14 @@ public class AuthenticationFailureTests : AuthClientFixture
     public async Task SignUp_ShouldThrowUserBadPassword_GivenWeakPassword()
     {
         var signUp = () => this.Client.SignUp(RandomEmail(), "x");
-        await VerifyRejectedWithSignOut(signUp, UserBadPassword);
+        await VerifyRejected(signUp, UserBadPassword);
     }
 
     [TestMethod]
     public async Task SignUp_ShouldThrowUserBadEmailAddress_GivenInvalidEmail()
     {
         var signUp = () => this.Client.SignUp("not a real email address", Password);
-        await VerifyRejectedWithSignOut(signUp, UserBadEmailAddress);
+        await VerifyRejected(signUp, UserBadEmailAddress);
     }
 
     [TestMethod]
@@ -45,11 +44,11 @@ public class AuthenticationFailureTests : AuthClientFixture
         this.StateChanges.Should().BeEmpty();
         var signUp = () => this.Client.SignUp(Constants.SignUpType.Phone, "", Password,
             new SignUpOptions { Data = new Dictionary<string, object> { { "firstName", "Testing" } } });
-        await VerifyRejectedWithSignOut(signUp, UserBadPhoneNumber);
+        await VerifyRejected(signUp, UserBadPhoneNumber);
     }
 
     [TestMethod]
-    public async Task SignUp_ShouldThrowUserAlreadyRegisteredAndDestroySession_GivenDuplicate()
+    public async Task SignUp_ShouldThrowUserAlreadyRegisteredAndKeepSession_GivenDuplicate()
     {
         var email = RandomEmail();
         await this.Client.SignUp(email, Password);
@@ -57,7 +56,9 @@ public class AuthenticationFailureTests : AuthClientFixture
         this.Persistence.LoadSession().Should().NotBeNull();
         this.StateChanges.Clear();
         var duplicate = () => this.Client.SignUp(email, Password);
-        await VerifyRejectedWithSignOut(duplicate, UserAlreadyRegistered);
+        await VerifyRejected(duplicate, UserAlreadyRegistered);
+        this.Persistence.LoadSession().Should().NotBeNull();
+        this.Client.CurrentSession.Should().NotBeNull();
     }
 
     [TestMethod]
@@ -77,11 +78,10 @@ public class AuthenticationFailureTests : AuthClientFixture
             "the server does not disclose whether an email is registered");
     }
 
-    private async Task VerifyRejectedWithSignOut(Func<Task> operation, FailureHint.Reason expected)
+    private async Task VerifyRejected(Func<Task> operation, FailureHint.Reason expected)
     {
         var exception = await operation.Should().ThrowAsync<GotrueException>();
         exception.Which.Reason.Should().Be(expected);
-        this.Persistence.LoadSession().Should().BeNull();
-        this.StateChanges.Should().ContainSingle().Which.Should().Be(SignedOut);
+        this.StateChanges.Should().BeEmpty();
     }
 }

--- a/packages/Gotrue/Gotrue.Tests/Authentication/OAuthSignInTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Authentication/OAuthSignInTests.cs
@@ -40,7 +40,6 @@ public class OAuthSignInTests : AuthClientFixture
     public async Task SignIn_ShouldReturnPkceVerifierAndChallengeUrl_GivenPkceFlow()
     {
         var result = await this.Client.SignIn(Constants.Provider.Github, new SignInOptions { FlowType = Constants.OAuthFlowType.PKCE });
-        this.VerifySignedOut();
         result.PKCEVerifier.Should().NotBeNullOrEmpty();
         result.Uri.Query.Should().Contain("flow_type=pkce")
             .And.Contain("code_challenge=")

--- a/packages/Gotrue/Gotrue.Tests/Authentication/SignInFailureContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Authentication/SignInFailureContractTests.cs
@@ -1,0 +1,74 @@
+#region
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Gotrue.Tests.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Gotrue;
+using Supabase.Gotrue.Exceptions;
+using Supabase.Gotrue.Interfaces;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using static Gotrue.Tests.TestUtils;
+
+#endregion
+
+namespace Gotrue.Tests.Authentication;
+
+/// <summary>
+///     Pins what a rejected or invalid sign-in leaves behind: the session the user already had (issue #396).
+/// </summary>
+[TestClass]
+[TestCategory("Contract")]
+public class SignInFailureContractTests
+{
+    private readonly List<Constants.AuthState> stateChanges = new();
+    private IGotrueClient<User, Session> client = null!;
+    private IGotrueSessionPersistence<Session> persistence = null!;
+    private MockGotrueServer server = null!;
+
+    [TestInitialize]
+    public void TestInitializer()
+    {
+        this.server = new MockGotrueServer();
+        this.client = TestClients.Against(this.server);
+        this.persistence = SessionPersistenceSubstitute.Tracking();
+        this.persistence.SaveSession(new Session { AccessToken = "an-access-token", RefreshToken = "a-refresh-token", ExpiresIn = 3600 });
+        this.client.SetPersistence(this.persistence);
+        this.client.LoadSession();
+        this.client.AddStateChangedListener((_, state) => this.stateChanges.Add(state));
+    }
+
+    [TestCleanup]
+    public void TestCleanup() => this.server.Dispose();
+
+    [TestMethod]
+    public async Task SignUp_ShouldKeepTheCurrentSession_GivenTheServerRejectsIt()
+    {
+        this.server.Given(Request.Create().WithPath("/signup").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(422)
+                .WithHeader("Content-Type", "application/json").WithBody("""{"code":422,"error_code":"user_already_exists","msg":"User already registered"}"""));
+        var signUp = () => this.client.SignUp(RandomEmail(), Password);
+        await signUp.Should().ThrowAsync<GotrueException>();
+        using (new AssertionScope())
+        {
+            this.client.CurrentSession!.RefreshToken.Should().Be("a-refresh-token", "a rejected sign-up must not sign the user out (issue #396)");
+            this.persistence.LoadSession().Should().NotBeNull();
+            this.stateChanges.Should().BeEmpty();
+        }
+    }
+
+    [TestMethod]
+    public async Task SetSession_ShouldKeepTheCurrentSession_GivenEmptyTokens()
+    {
+        var setSession = () => this.client.SetSession("", "");
+        await setSession.Should().ThrowAsync<GotrueException>();
+        using (new AssertionScope())
+        {
+            this.client.CurrentSession!.RefreshToken.Should().Be("a-refresh-token");
+            this.stateChanges.Should().BeEmpty();
+        }
+    }
+}

--- a/packages/Gotrue/Gotrue.Tests/Support/AuthClientFixture.cs
+++ b/packages/Gotrue/Gotrue.Tests/Support/AuthClientFixture.cs
@@ -61,7 +61,7 @@ public abstract class AuthClientFixture
     {
         using (new AssertionScope())
         {
-            StateChanges.Should().Contain(SignedOut);
+            StateChanges.Should().ContainSingle(state => state == SignedOut);
             Persistence.LoadSession().Should().BeNull();
             Client.CurrentSession.Should().BeNull();
             Client.CurrentUser.Should().BeNull();

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/RefreshContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/RefreshContractTests.cs
@@ -39,6 +39,10 @@ public class RefreshContractTests
     {
         server = new MockGotrueServer();
         client = TestClients.Against(server);
+        var persistence = SessionPersistenceSubstitute.Tracking();
+        persistence.SaveSession(new Session { AccessToken = AccessToken, RefreshToken = RefreshTokenValue, ExpiresIn = 3600 });
+        this.client.SetPersistence(persistence);
+        this.client.LoadSession();
     }
 
     [TestCleanup]
@@ -96,13 +100,26 @@ public class RefreshContractTests
     }
 
     [TestMethod]
-    public async Task RefreshToken_ShouldThrowUnknownAndDestroySession_GivenUnrecognizedError()
+    public async Task RefreshToken_ShouldThrowUnknownAndKeepSession_GivenUnrecognizedError()
     {
         MockErrorResponse(500, Fixture("unclassified_error.json"));
         var refresh = () => client.RefreshToken(AccessToken, RefreshTokenValue);
         var exception = await refresh.Should().ThrowAsync<GotrueException>();
         exception.Which.Reason.Should().Be(Unknown);
-        client.CurrentSession.Should().BeNull();
+        client.CurrentSession.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public async Task RefreshToken_ShouldKeepTheCurrentSession_GivenAForeignTokenIsRejected()
+    {
+        var stateChanges = new List<Constants.AuthState>();
+        this.client.AddStateChangedListener((_, state) => stateChanges.Add(state));
+        this.MockErrorResponse(400, Fixture("token_not_found_error.json"));
+        var refresh = () => this.client.RefreshToken("another-access-token", "another-refresh-token");
+        await refresh.Should().ThrowAsync<GotrueException>();
+        this.client.CurrentSession!.RefreshToken.Should().Be(RefreshTokenValue,
+            "a refresh rejected for another session must not sign the current one out (issue #396)");
+        stateChanges.Should().NotContain(SignedOut);
     }
 
     private void MockSuccessResponse() =>

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/RefreshContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/RefreshContractTests.cs
@@ -91,7 +91,7 @@ public class RefreshContractTests
         MockErrorResponse(400, Fixture("token_not_found_error.json"));
         var refresh = () => client.RefreshToken(AccessToken, RefreshTokenValue);
         await refresh.Should().ThrowAsync<GotrueException>();
-        stateChanges.Should().Contain(SignedOut,
+        stateChanges.Should().ContainSingle(state => state == SignedOut,
             "a rejected refresh must notify listeners the session ended — the auto-refresh timer swallows the exception, so the SignedOut event is the only way a background refresh failure reaches the app (issue #91)");
     }
 

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -302,6 +302,33 @@ public class SessionRestoreContractTests
     }
 
     [TestMethod]
+    public async Task RetrieveSessionAsync_ShouldKeepTheReplacementPersisted_GivenTheRejectionLandedAfterASignIn()
+    {
+        var destroyStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var destroyGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        this.persistence = HeldDestroyStore(destroyStarted, destroyGate.Task);
+        this.persistence.SaveSession(new Session { AccessToken = "an-access-token", RefreshToken = "a-refresh-token", ExpiresIn = 3600 });
+        var handler = new GatedHandler(HttpStatusCode.BadRequest, "token_not_found_error.json");
+        var client = this.Restore(TestClients.Against(this.server, autoRefreshToken: true, new HttpClient(handler)));
+        var retrieve = client.RetrieveSessionAsync();
+        await handler.Started;
+        handler.Release();
+        await destroyStarted.Task.WaitAsync(HandlerTimeout);
+
+        // The sign-in installs and persists its session while the rejection's destroy is still in flight.
+        this.persistence.SaveSession(new Session { AccessToken = "another-access-token", RefreshToken = "another-refresh-token", ExpiresIn = 3600 });
+        client.LoadSession();
+        var signIn = client.NotifyAuthStateChangeAsync(SignedIn);
+        destroyGate.SetResult(true);
+        await signIn;
+        await retrieve;
+
+        this.persistence.LoadSession()!.RefreshToken.Should().Be("another-refresh-token",
+            "the destroy belonged to the rejected session, so it must not wipe what the sign-in saved (issue #396)");
+        client.CurrentSession!.RefreshToken.Should().Be("another-refresh-token");
+    }
+
+    [TestMethod]
     public void LoadSession_ShouldClearTheSession_GivenTheStoreWasEmptied()
     {
         var client = this.Restore(TestClients.Against(this.server));
@@ -347,6 +374,21 @@ public class SessionRestoreContractTests
     {
         this.clients.Add(client);
         return client;
+    }
+
+    /// <summary>
+    ///     A tracking store whose async destroy waits on a gate, so a test can hold a sign-out's write in flight.
+    /// </summary>
+    private static IGotrueSessionPersistence<Session> HeldDestroyStore(TaskCompletionSource<bool> started, Task gate)
+    {
+        var store = SessionPersistenceSubstitute.Tracking();
+        store.DestroySessionAsync(Arg.Any<CancellationToken>()).Returns(async _ =>
+        {
+            started.TrySetResult(true);
+            await gate;
+            store.DestroySession();
+        });
+        return store;
     }
 
     private static string Fixture(string name) =>

--- a/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/TokenRefresh/SessionRestoreContractTests.cs
@@ -165,17 +165,15 @@ public class SessionRestoreContractTests
     }
 
     [TestMethod]
-    public async Task TokenRefresh_ShouldRescheduleFromTheRefreshedSession_GivenARefreshOutsideTheTimer()
+    public async Task TokenRefresh_ShouldWaitATick_GivenTheRefreshedSessionIsAboutToExpire()
     {
         var handler = new GatedHandler(fixture: "token_success_expiring.json");
         var client = this.Restore(TestClients.Against(this.server, autoRefreshToken: true, new HttpClient(handler)));
         handler.Release();
         await client.RetrieveSessionAsync();
-        var secondAttempt = () => handler.SecondAttempt;
-        await secondAttempt.Should().NotThrowAsync(
-            "the refreshed session expires in a second, so the timer must be rescheduled from it instead of the restored session's deadline an hour out");
-        // Every refresh hands back the same one second session, so stop the timer now the point is made.
-        client.Online = false;
+        await Task.Delay(250);
+        handler.Attempts.Should().Be(1,
+            "the refreshed session expires in a second, so without a floor the timer re-arms at zero and hammers the token endpoint (issue #396)");
     }
 
     [TestMethod]
@@ -420,7 +418,6 @@ public class SessionRestoreContractTests
     {
         private readonly TaskCompletionSource<bool> gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ConcurrentQueue<string?> refreshTokens = new();
-        private readonly TaskCompletionSource<bool> secondAttempt = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource<bool> started = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public int Attempts => this.refreshTokens.Count;
@@ -430,9 +427,6 @@ public class SessionRestoreContractTests
 
         /// <summary>Completes when the first refresh reaches the handler, so a test can act while it is held.</summary>
         public Task Started => this.started.Task.WaitAsync(HandlerTimeout);
-
-        /// <summary>Completes when a second refresh reaches the handler, so a test can wait for the next scheduled one.</summary>
-        public Task SecondAttempt => this.secondAttempt.Task.WaitAsync(HandlerTimeout);
 
         public void Release() => this.gate.TrySetResult(true);
 
@@ -445,10 +439,6 @@ public class SessionRestoreContractTests
             var body = JsonNode.Parse(await request.Content!.ReadAsStringAsync(cancellationToken))!.AsObject();
             this.refreshTokens.Enqueue(body["refresh_token"]?.GetValue<string>());
             this.started.TrySetResult(true);
-            if (this.refreshTokens.Count >= 2)
-            {
-                this.secondAttempt.TrySetResult(true);
-            }
             await this.gate.Task.WaitAsync(HandlerTimeout, cancellationToken);
             return new HttpResponseMessage(status)
             {

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -497,7 +497,6 @@ public class Client : IGotrueClient<User, Session>
             await this.api.SignOut(this.CurrentSession.AccessToken, scope);
         }
         await this.UpdateSessionAsync(null).ConfigureAwait(false);
-        await this.NotifyAuthStateChangeAsync(SignedOut).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -769,7 +768,6 @@ public class Client : IGotrueClient<User, Session>
         {
             activity.SetFailure(ex);
             await this.DestroySessionAsync().ConfigureAwait(false);
-            await this.NotifyAuthStateChangeAsync(SignedOut).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
@@ -857,7 +855,6 @@ public class Client : IGotrueClient<User, Session>
             if (stillOurs)
             {
                 await this.DestroySessionAsync().ConfigureAwait(false);
-                await this.NotifyAuthStateChangeAsync(SignedOut).ConfigureAwait(false);
             }
             throw;
         }

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -200,7 +200,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         var session = type switch
         {
             SignUpType.Email => await this.api.SignUpWithEmail(identifier, password, options),
@@ -238,7 +237,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         var result = await this.api.SignInWithIdToken(provider, idToken, accessToken, nonce, captchaToken);
         await this.UpdateSessionAsync(result).ConfigureAwait(false);
         await this.NotifyAuthStateChangeAsync(SignedIn).ConfigureAwait(false);
@@ -254,7 +252,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         return await this.api.SignInWithOtp(options);
     }
 
@@ -267,7 +264,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         return await this.api.SignInWithOtp(options);
     }
 
@@ -333,7 +329,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         return this.api.GetUriForProvider(provider, options);
     }
 
@@ -344,7 +339,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         return await this.api.SignInWithSSO(providerId, options).ConfigureAwait(false);
     }
 
@@ -355,7 +349,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         return await this.api.SignInWithSSO(domain, options).ConfigureAwait(false);
     }
 
@@ -367,7 +360,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         var newSession = await this.api.SignInAnonymously(options);
         await this.UpdateSessionAsync(newSession).ConfigureAwait(false);
         await this.NotifyAuthStateChangeAsync(SignedIn).ConfigureAwait(false);
@@ -383,7 +375,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         var session = await this.api.VerifyMobileOTP(phone, token, type);
         if (session?.AccessToken != null)
         {
@@ -403,7 +394,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         var session = await this.api.VerifyEmailOTP(email, token, type);
         if (session?.AccessToken != null)
         {
@@ -422,7 +412,6 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        await this.DestroySessionAsync().ConfigureAwait(false);
         var session = await this.api.VerifyTokenHash(tokenHash, type);
         if (session?.AccessToken != null)
         {
@@ -573,7 +562,6 @@ public class Client : IGotrueClient<User, Session>
     public async Task<Session> SetSession(string accessToken, string refreshToken, bool forceAccessTokenRefresh = false)
     {
         using var activity = GotrueInstrumentation.Source.StartActivity(GotrueInstrumentation.Spans.SetSession);
-        await this.DestroySessionAsync().ConfigureAwait(false);
         if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(refreshToken))
         {
             throw new GotrueException("`accessToken` and `refreshToken` cannot be empty.", NoSessionFound);

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -507,7 +507,8 @@ public class Client : IGotrueClient<User, Session>
     public async Task<User?> Update(UserAttributes attributes)
     {
         using var activity = GotrueInstrumentation.Source.StartActivity(GotrueInstrumentation.Spans.UpdateUser);
-        if (this.CurrentSession == null || string.IsNullOrEmpty(this.CurrentSession.AccessToken))
+        var session = this.CurrentSession;
+        if (session == null || string.IsNullOrEmpty(session.AccessToken))
         {
             throw new GotrueException("Not Logged in.");
         }
@@ -515,8 +516,14 @@ public class Client : IGotrueClient<User, Session>
         {
             throw new GotrueException("Only supported when online", Offline);
         }
-        var result = await this.api.UpdateUser(this.CurrentSession.AccessToken!, attributes);
-        this.CurrentSession.User = result;
+        var result = await this.api.UpdateUser(session.AccessToken!, attributes);
+        // The session may have refreshed meanwhile, so the update lands on the current one if it is still this user's.
+        var current = this.CurrentSession;
+        if (current == null || current.User?.Id != result?.Id)
+        {
+            return result;
+        }
+        current.User = result;
         await this.NotifyAuthStateChangeAsync(UserUpdated).ConfigureAwait(false);
         return result;
     }

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -578,14 +578,14 @@ public class Client : IGotrueClient<User, Session>
             {
                 throw new GotrueException("Could not generate a session given the provided parameters.", NoSessionFound);
             }
-            this.CurrentSession = result;
+            this.SetCurrentSession(result);
             await this.NotifyAuthStateChangeAsync(SignedIn).ConfigureAwait(false);
-            return this.CurrentSession;
+            return result;
         }
         var iat = payload.IssuedAt;
         var exp = payload.ValidTo;
         var expiresIn = (long) (exp - iat).TotalSeconds;
-        this.CurrentSession = new Session
+        var session = new Session
         {
             AccessToken = accessToken,
             RefreshToken = refreshToken,
@@ -593,8 +593,9 @@ public class Client : IGotrueClient<User, Session>
             ExpiresIn = expiresIn,
             User = await this.api.GetUser(accessToken),
         };
+        this.SetCurrentSession(session);
         await this.NotifyAuthStateChangeAsync(SignedIn).ConfigureAwait(false);
-        return this.CurrentSession;
+        return session;
     }
 
     /// <summary>
@@ -749,7 +750,7 @@ public class Client : IGotrueClient<User, Session>
             {
                 throw new GotrueException("Could not refresh token from provided session.", NoSessionFound);
             }
-            this.CurrentSession = result;
+            this.SetCurrentSession(result);
             await this.NotifyAuthStateChangeAsync(TokenRefreshed).ConfigureAwait(false);
         }
         catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken)
@@ -821,14 +822,10 @@ public class Client : IGotrueClient<User, Session>
             {
                 throw new GotrueException("Could not refresh token from provided session.", NoSessionFound);
             }
-            lock (this.refreshGate)
+            // The session was replaced while this call was in flight, so the result is the previous user's.
+            if (!this.TryReplaceSession(result, refreshToken))
             {
-                // The session was replaced while this call was in flight, so the result is the previous user's.
-                if (this.CurrentSession?.RefreshToken != refreshToken)
-                {
-                    return;
-                }
-                this.CurrentSession = result;
+                return;
             }
             await this.NotifyAuthStateChangeAsync(TokenRefreshed).ConfigureAwait(false);
         }
@@ -1104,6 +1101,20 @@ public class Client : IGotrueClient<User, Session>
             return SignedOut;
         }
         return dirty ? UserUpdated : null;
+    }
+
+    // Writes the session only while the given refresh token is still the current one.
+    private bool TryReplaceSession(Session? session, string expectedRefreshToken)
+    {
+        lock (this.refreshGate)
+        {
+            if (this.CurrentSession?.RefreshToken != expectedRefreshToken)
+            {
+                return false;
+            }
+            this.SetCurrentSession(session);
+            return true;
+        }
     }
 
     private async Task UpdateSessionAsync(Session? session, CancellationToken cancellationToken = default)

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -613,9 +613,19 @@ public class Client : IGotrueClient<User, Session>
             RefreshToken = refreshToken,
             TokenType = "bearer",
             ExpiresIn = expiresIn,
-            User = await this.api.GetUser(accessToken),
         };
+        // Installed before the user is fetched, so a refresh meanwhile moves to these tokens instead of spending them.
         this.SetCurrentSession(session);
+        try
+        {
+            session.User = await this.api.GetUser(accessToken);
+        }
+        catch
+        {
+            // Nothing was announced yet, so the failed install just goes away.
+            this.TryReplaceSession(null, refreshToken);
+            throw;
+        }
         await this.NotifyAuthStateChangeAsync(SignedIn).ConfigureAwait(false);
         return session;
     }

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -53,6 +53,11 @@ public class Client : IGotrueClient<User, Session>
     private readonly object refreshGate = new();
 
     /// <summary>
+    ///     Orders persistence writes, so a destroy in flight cannot land after the save that replaced it.
+    /// </summary>
+    private readonly SemaphoreSlim persistenceGate = new(1, 1);
+
+    /// <summary>
     ///     The running token refresh, shared by concurrent callers. A completed attempt is replaced, never reused.
     /// </summary>
     internal RefreshAttempt? refreshAttempt;
@@ -129,13 +134,23 @@ public class Client : IGotrueClient<User, Session>
         {
             return;
         }
+        await this.persistenceGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            // A SignedOut that finds a session was raced by a sign-in, and must not wipe what that sign-in saved.
+            if (stateChanged == SignedOut && this.CurrentSession != null)
+            {
+                return;
+            }
             await this.sessionPersistence.EventHandlerAsync(this, stateChanged, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e)
         {
             this.debugNotification?.Log("Auth State Change Handler Failure", e);
+        }
+        finally
+        {
+            this.persistenceGate.Release();
         }
     }
 
@@ -756,7 +771,7 @@ public class Client : IGotrueClient<User, Session>
         catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken)
         {
             activity.SetFailure(ex);
-            await this.DestroySessionAsync().ConfigureAwait(false);
+            await this.ClearRejectedSessionAsync(refreshToken).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
@@ -832,15 +847,7 @@ public class Client : IGotrueClient<User, Session>
         catch (GotrueException ex) when (ex.Reason is InvalidRefreshToken)
         {
             activity.SetFailure(ex);
-            bool stillOurs;
-            lock (this.refreshGate)
-            {
-                stillOurs = this.CurrentSession?.RefreshToken == refreshToken;
-            }
-            if (stillOurs)
-            {
-                await this.DestroySessionAsync().ConfigureAwait(false);
-            }
+            await this.ClearRejectedSessionAsync(refreshToken).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
@@ -1125,7 +1132,15 @@ public class Client : IGotrueClient<User, Session>
         }
     }
 
-    private Task DestroySessionAsync(CancellationToken cancellationToken = default) => this.UpdateSessionAsync(null, cancellationToken);
+    // Only signs out the session the token belonged to.
+    private async Task ClearRejectedSessionAsync(string refreshToken)
+    {
+        if (!this.TryReplaceSession(null, refreshToken) || this.CurrentSession != null)
+        {
+            return;
+        }
+        await this.NotifyAuthStateChangeAsync(SignedOut).ConfigureAwait(false);
+    }
 
     /// <summary>
     ///     A token refresh in flight, with the refresh token it was started for. A caller holding a different

--- a/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
+++ b/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
@@ -523,9 +523,10 @@ public interface IGotrueClient<TUser, TSession> : IGettableHeaders
     ///     current session with the result. Useful when resuming from a persisted session:
     ///     the refresh token is one-time-use and never expires server-side, so it can mint a
     ///     new session even if the access token has long expired.
-    ///     If the server rejects the refresh token, the current session is destroyed and a
+    ///     If the server rejects the refresh token, a
     ///     <see cref="Exceptions.GotrueException" /> with reason
-    ///     <see cref="Exceptions.FailureHint.Reason.InvalidRefreshToken" /> is thrown.
+    ///     <see cref="Exceptions.FailureHint.Reason.InvalidRefreshToken" /> is thrown, and the
+    ///     session is destroyed if it is still the current one.
     /// </summary>
     /// <param name="accessToken">The access token to send as the bearer authorization.</param>
     /// <param name="refreshToken">The refresh token to exchange for a new session.</param>

--- a/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
+++ b/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
@@ -159,13 +159,12 @@ public interface IGotrueClient<TUser, TSession> : IGettableHeaders
 
     /// <summary>
     ///     Sets a new session given a user's access token and their refresh token.
-    ///     1. Will destroy the current session (if existing)
-    ///     2. Raise a <see cref="AuthState.SignedOut" /> event.
-    ///     3. Decode token
-    ///     3a. If expired (or bool <paramref name="forceAccessTokenRefresh"></paramref> set), force an access token refresh.
-    ///     3b. If not expired, set the <see cref="CurrentSession" /> and retrieve <see cref="CurrentUser" /> from the server
+    ///     1. Decode token
+    ///     1a. If expired (or bool <paramref name="forceAccessTokenRefresh"></paramref> set), force an access token refresh.
+    ///     1b. If not expired, set the <see cref="CurrentSession" /> and retrieve <see cref="CurrentUser" /> from the server
     ///     using the <paramref name="accessToken" />.
-    ///     4. Raise a `<see cref="AuthState.SignedIn" /> event if successful.
+    ///     2. Raise a `<see cref="AuthState.SignedIn" /> event if successful.
+    ///     The current session (if any) is kept until the new one replaces it.
     /// </summary>
     /// <param name="accessToken"></param>
     /// <param name="refreshToken"></param>
@@ -211,7 +210,6 @@ public interface IGotrueClient<TUser, TSession> : IGettableHeaders
     ///     if you are using phone sign in with the 'whatsapp' channel. The whatsapp
     ///     channel is not supported on other providers at this time.
     /// </summary>
-    /// <remarks>Calling this method will wipe out the current session (if any)</remarks>
     /// <param name="options"></param>
     /// <returns></returns>
     Task<PasswordlessSignInState> SignInWithOtp(SignInWithPasswordlessEmailOptions options);
@@ -228,7 +226,6 @@ public interface IGotrueClient<TUser, TSession> : IGettableHeaders
     ///     if you are using phone sign in with the 'whatsapp' channel. The whatsapp
     ///     channel is not supported on other providers at this time.
     /// </summary>
-    /// <remarks>Calling this method will wipe out the current session (if any)</remarks>
     /// <param name="options"></param>
     /// <returns></returns>
     Task<PasswordlessSignInState> SignInWithOtp(SignInWithPasswordlessPhoneOptions options);
@@ -274,7 +271,6 @@ public interface IGotrueClient<TUser, TSession> : IGettableHeaders
     ///     the ID token.
     /// </param>
     /// <param name="captchaToken">Verification token received when the user completes the captcha on the site.</param>
-    /// <remarks>Calling this method will eliminate the current session (if any).</remarks>
     /// <exception>
     ///     <cref>InvalidProviderException</cref>
     /// </exception>
@@ -328,7 +324,6 @@ public interface IGotrueClient<TUser, TSession> : IGettableHeaders
     ///     Signs up a user with an email or phone identifier.
     /// </summary>
     /// <remarks>
-    ///     Calling this method logs out the current session (if any).
     ///     Returns a <see cref="Session" /> whose <see cref="Session.User" /> is the signed-up user. Whether that
     ///     session is usable depends on your project's Confirm email/phone settings:
     ///     - Confirmation required: the user must confirm first. The returned user is unconfirmed
@@ -359,7 +354,6 @@ public interface IGotrueClient<TUser, TSession> : IGettableHeaders
     ///     Signs up a user by email address.
     /// </summary>
     /// <remarks>
-    ///     Calling this method logs out the current session (if any).
     ///     Returns a <see cref="Session" /> whose <see cref="Session.User" /> is the signed-up user. Whether that
     ///     session is usable depends on your project's Confirm email setting:
     ///     - Confirm email enabled: the user must confirm their address first. The returned user is unconfirmed

--- a/packages/Gotrue/Gotrue/TokenRefresh.cs
+++ b/packages/Gotrue/Gotrue/TokenRefresh.cs
@@ -13,11 +13,16 @@ public class TokenRefresh
     private readonly Client _client;
 
     /// <summary>
-    /// Minimum wait between refresh attempts after one was skipped or failed.
-    /// supabase-js polls on a fixed 30 second tick (AUTO_REFRESH_TICK_DURATION_MS) and
-    /// picks a failed refresh up on the next one, so a failed attempt waits one tick too.
+    /// Minimum wait between refresh attempts.
+    /// supabase-js polls on a fixed 30 second tick (AUTO_REFRESH_TICK_DURATION_MS) and picks a
+    /// refresh up on the next one, so an attempt never follows another sooner than a tick.
     /// </summary>
     private static readonly TimeSpan AutoRefreshTickDuration = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Guards the timer field, so a stop and a re-arm cannot interleave.
+    /// </summary>
+    private readonly object timerGate = new();
 
     /// <summary>
     /// Internal timer reference for token refresh
@@ -26,6 +31,11 @@ public class TokenRefresh
     /// </see>
     /// </summary>
     private Timer? _refreshTimer;
+
+    /// <summary>
+    /// Set by Shutdown, so a tick or refresh still in flight cannot bring the timer back.
+    /// </summary>
+    private volatile bool stopped;
 
     /// <summary>
     /// Turn on debug logging for the TokenRefresh
@@ -54,23 +64,42 @@ public class TokenRefresh
                 // Turn on auto-refresh timer
                 break;
             case SignedOut:
+                this.StopTimer();
+                break;
             case Shutdown:
-                if (this.Debug)
-                    this._client.Debug("Refresh Timer stopped");
-                this._refreshTimer?.Dispose();
-                // Turn off auto-refresh timer
+                this.stopped = true;
+                this.StopTimer();
                 break;
             case UserUpdated:
-            case TokenRefreshed:
                 if (this.Debug)
                     this._client.Debug("Refresh Timer restarted");
                 this.CreateNewTimer();
+                break;
+            case TokenRefreshed:
+                if (this.Debug)
+                    this._client.Debug("Refresh Timer restarted");
+                // A fresh token needs no refresh within a tick, so a zero expires_in cannot hot-loop.
+                this.CreateNewTimer(AutoRefreshTickDuration);
                 break;
             case PasswordRecovery:
             case MfaChallengeVerified:
                 // Doesn't affect auto refresh
                 break;
             default: throw new ArgumentOutOfRangeException(nameof(stateChanged), stateChanged, null);
+        }
+    }
+
+    private void StopTimer()
+    {
+        lock (this.timerGate)
+        {
+            // A sign-in raced this SignedOut, so its timer stays.
+            if (!this.stopped && this._client.CurrentSession != null)
+                return;
+            if (this.Debug)
+                this._client.Debug("Refresh Timer stopped");
+            this._refreshTimer?.Dispose();
+            this._refreshTimer = null;
         }
     }
 
@@ -98,9 +127,12 @@ public class TokenRefresh
         }
         finally
         {
-            // An expired session schedules at zero, so a refresh that was skipped or
-            // failed must wait a tick before the next attempt instead of hot-looping.
-            this.CreateNewTimer(refreshCompleted ? TimeSpan.Zero : AutoRefreshTickDuration);
+            // A successful refresh is rescheduled by TokenRefreshed, a skipped or failed
+            // one waits a tick instead of hot-looping on a session that schedules at zero.
+            if (!refreshCompleted)
+            {
+                this.CreateNewTimer(AutoRefreshTickDuration);
+            }
         }
     }
 
@@ -115,20 +147,22 @@ public class TokenRefresh
     /// </summary>
     private void CreateNewTimer(TimeSpan minimumDelay = default)
     {
-        if (this._client.CurrentSession == null)
-        {
-            if (this.Debug)
-                this._client.Debug($"No session, refresh timer not started");
-            return;
-        }
-
         try
         {
             var refreshDueTime = this.GetSecondsUntilNextRefresh();
             if (refreshDueTime < minimumDelay)
                 refreshDueTime = minimumDelay;
-            this._refreshTimer?.Dispose();
-            this._refreshTimer = new Timer(this.HandleRefreshTimerTick, null, refreshDueTime, Timeout.InfiniteTimeSpan);
+            lock (this.timerGate)
+            {
+                if (this.stopped || this._client.CurrentSession == null)
+                {
+                    if (this.Debug)
+                        this._client.Debug($"No session, refresh timer not started");
+                    return;
+                }
+                this._refreshTimer?.Dispose();
+                this._refreshTimer = new Timer(this.HandleRefreshTimerTick, null, refreshDueTime, Timeout.InfiniteTimeSpan);
+            }
 
             if (this.Debug)
                 this._client.Debug($"Refresh timer scheduled {refreshDueTime.TotalMinutes} minutes");


### PR DESCRIPTION
closes #396

sign-up, otp, sso, id token, verify and `SetSession` cleared the current session and raised `SignedOut` before talking to the server, so a rejected attempt signed the user out and a cold start fired the event for nothing. now a sign-in only replaces the session once it succeeds, same as supabase-js. `SetSession` validates first and installs the tokens before fetching the user, so a refresh landing meanwhile moves to them instead of spending them.

a rejected refresh only signs out the session the token belonged to. the check and the clear share one hold of the gate, persistence writes are ordered so a destroy in flight can't land after the save that replaced it, and a stale `SignedOut` that finds a live session leaves the store and the timer alone. the 2-arg `RefreshToken` gets the same guard, it used to destroy whatever session was current.

`SignOut` raises `SignedOut` once instead of twice. the refresh timer keeps the 30s floor after a successful refresh too, a session with `expires_in` 0 hot-looped the token endpoint, and it stays stopped after `Shutdown`. `Update` lands on the current session only if it's still the same user.