### PR TITLE
feat(realtime): add `enabled` flag for opt-in initial presence sync

### DIFF
--- a/packages/Realtime/Realtime.Tests/Channels/Data/SubscribeFrameApprovalTests.JoinFrame_ShouldSerializeBroadcastAndPresence_GivenOptions.verified.txt
+++ b/packages/Realtime/Realtime.Tests/Channels/Data/SubscribeFrameApprovalTests.JoinFrame_ShouldSerializeBroadcastAndPresence_GivenOptions.verified.txt
@@ -1,1 +1,1 @@
-﻿{"topic":"realtime:room:1","event":"phx_join","payload":{"config":{"broadcast":{"self":true,"ack":true},"presence":{"key":"client-1"},"postgres_changes":[],"private":false}},"ref":"1","join_ref":"1"}
+﻿{"topic":"realtime:room:1","event":"phx_join","payload":{"config":{"broadcast":{"self":true,"ack":true},"presence":{"key":"client-1","enabled":true},"postgres_changes":[],"private":false}},"ref":"1","join_ref":"1"}

--- a/packages/Realtime/Realtime.Tests/Channels/SubscribeFrameApprovalTests.cs
+++ b/packages/Realtime/Realtime.Tests/Channels/SubscribeFrameApprovalTests.cs
@@ -48,7 +48,7 @@ public class SubscribeFrameApprovalTests : FrameApprovalFixture
     {
         var payload = JoinPush.ForPublicChannel(
             new BroadcastOptions(broadcastSelf: true, broadcastAck: true),
-            new PresenceOptions("client-1"));
+            new PresenceOptions("client-1", enabled: true));
         await this.Verify(this.Encode(JoinFrame("realtime:room:1", payload))).UseDirectory("Data");
     }
 }

--- a/packages/Realtime/Realtime.Tests/Presence/PresenceRegistrationTests.cs
+++ b/packages/Realtime/Realtime.Tests/Presence/PresenceRegistrationTests.cs
@@ -45,4 +45,15 @@ public class PresenceRegistrationTests
         presence["key"]!.GetValue<string>().Should().Be("some-key");
         presence["enabled"]!.GetValue<bool>().Should().BeTrue();
     }
+
+    [TestMethod]
+    public void GenerateJoinPush_ShouldOmitPresence_GivenNoRegistration()
+    {
+        var channel = Wire.Channel();
+        var payload = channel.GenerateJoinPush().Payload!;
+        var config = JsonNode.Parse(JsonSerializer.Serialize(payload, payload.GetType(), Wire.Settings()))!["config"]!
+            .AsObject();
+
+        config.ContainsKey("presence").Should().BeFalse();
+    }
 }

--- a/packages/Realtime/Realtime.Tests/Presence/PresenceRegistrationTests.cs
+++ b/packages/Realtime/Realtime.Tests/Presence/PresenceRegistrationTests.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Realtime.Tests.Models;
+using Realtime.Tests.Support;
+using Supabase.Realtime;
+using Supabase.Realtime.Presence;
+
+namespace Realtime.Tests.Presence;
+
+/// <summary>
+///     Regression tests for presence join configuration: checks that proper config properties are present for
+///     different registration paths.
+/// </summary>
+[TestClass]
+[TestCategory("Unit")]
+public class PresenceRegistrationTests
+{
+    private static JsonObject PresenceConfig(RealtimeChannel channel)
+    {
+        var payload = channel.GenerateJoinPush().Payload!;
+        var frame = JsonNode.Parse(JsonSerializer.Serialize(payload, payload.GetType(), Wire.Settings()))!.AsObject();
+        return frame["config"]!["presence"]!.AsObject();
+    }
+
+    [TestMethod]
+    public void Register_ShouldIncludeEnabledInJoinPayload_GivenStringKey()
+    {
+        var channel = Wire.Channel();
+        channel.Register<PresenceExample>("some-key");
+
+        var presence = PresenceConfig(channel);
+        presence["key"]!.GetValue<string>().Should().Be("some-key");
+        presence["enabled"]!.GetValue<bool>().Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Register_ShouldIncludeEnabledInJoinPayload_GivenPresenceOptions()
+    {
+        var channel = Wire.Channel();
+        channel.Register<PresenceExample>(new PresenceOptions("some-key", enabled: true));
+
+        var presence = PresenceConfig(channel);
+        presence["key"]!.GetValue<string>().Should().Be("some-key");
+        presence["enabled"]!.GetValue<bool>().Should().BeTrue();
+    }
+}

--- a/packages/Realtime/Realtime.Tests/Serialization/JoinPushConfigTests.cs
+++ b/packages/Realtime/Realtime.Tests/Serialization/JoinPushConfigTests.cs
@@ -58,5 +58,6 @@ public class JoinPushConfigTests
     {
         var config = Config(JoinPush.ForPublicChannel(presenceOptions: new PresenceOptions("client-1")));
         config["presence"]!["key"]!.GetValue<string>().Should().Be("client-1");
+        config["presence"]!["enabled"]!.GetValue<bool>().Should().BeTrue();
     }
 }

--- a/packages/Realtime/Realtime.Tests/Serialization/JoinPushConfigTests.cs
+++ b/packages/Realtime/Realtime.Tests/Serialization/JoinPushConfigTests.cs
@@ -56,7 +56,7 @@ public class JoinPushConfigTests
     [TestMethod]
     public void ForPublicChannel_ShouldSerialisePresenceKey_GivenProvided()
     {
-        var config = Config(JoinPush.ForPublicChannel(presenceOptions: new PresenceOptions("client-1")));
+        var config = Config(JoinPush.ForPublicChannel(presenceOptions: new PresenceOptions("client-1", enabled: true)));
         config["presence"]!["key"]!.GetValue<string>().Should().Be("client-1");
         config["presence"]!["enabled"]!.GetValue<bool>().Should().BeTrue();
     }

--- a/packages/Realtime/Realtime/Interfaces/IRealtimeChannel.cs
+++ b/packages/Realtime/Realtime/Interfaces/IRealtimeChannel.cs
@@ -263,11 +263,11 @@ public interface IRealtimeChannel
         where TPresenceResponse : BasePresence;
 
     /// <summary>
-    /// Register presence options, must be called to use <see cref="IRealtimePresence"/>, and prior to <see cref="Subscribe"/>
+    /// Registers a <see cref="RealtimePresence{TPresenceResponse}"/> instance with the specified options.
     /// </summary>
-    /// <param name="options"></param>
-    /// <typeparam name="TPresenceResponse"></typeparam>
-    /// <returns></returns>
+    /// <typeparam name="TPresenceResponse">The model representing a presence payload.</typeparam>
+    /// <param name="options">The presence options to configure the channel's behavior.</param>
+    /// <returns>A <see cref="RealtimePresence{TPresenceResponse}"/> instance for managing presence state.</returns>
     RealtimePresence<TPresenceResponse> Register<TPresenceResponse>(PresenceOptions options)
         where TPresenceResponse : BasePresence;
 

--- a/packages/Realtime/Realtime/Interfaces/IRealtimeChannel.cs
+++ b/packages/Realtime/Realtime/Interfaces/IRealtimeChannel.cs
@@ -263,6 +263,15 @@ public interface IRealtimeChannel
         where TPresenceResponse : BasePresence;
 
     /// <summary>
+    /// Register presence options, must be called to use <see cref="IRealtimePresence"/>, and prior to <see cref="Subscribe"/>
+    /// </summary>
+    /// <param name="options"></param>
+    /// <typeparam name="TPresenceResponse"></typeparam>
+    /// <returns></returns>
+    RealtimePresence<TPresenceResponse> Register<TPresenceResponse>(PresenceOptions options)
+        where TPresenceResponse : BasePresence;
+
+    /// <summary>
     /// Register postgres_changes options, must be called to use <see cref="PostgresChangesHandler"/>, and
     /// prior to <see cref="Subscribe"/>
     /// </summary>

--- a/packages/Realtime/Realtime/Presence/PresenceOptions.cs
+++ b/packages/Realtime/Realtime/Presence/PresenceOptions.cs
@@ -24,7 +24,7 @@ public class PresenceOptions
     /// Presence options.
     /// </summary>
     /// <param name="presenceKey"></param>
-    public PresenceOptions(string presenceKey) => this.PresenceKey = presenceKey;
+    public PresenceOptions(string presenceKey) : this(presenceKey, enabled: true) { }
 
     /// <summary>
     /// Presence options.

--- a/packages/Realtime/Realtime/Presence/PresenceOptions.cs
+++ b/packages/Realtime/Realtime/Presence/PresenceOptions.cs
@@ -14,8 +14,20 @@ public class PresenceOptions
     public string PresenceKey { get; set; }
 
     /// <summary>
+    /// Whether presence tracking is enabled for this channel join. Requires
+    /// <c>enabled: true</c> to receive the initial <c>presence_state</c> sync.
+    /// </summary>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
+    /// <summary>
     /// Presence options.
     /// </summary>
     /// <param name="presenceKey"></param>
-    public PresenceOptions(string presenceKey) => this.PresenceKey = presenceKey;
+    /// <param name="enabled"></param>
+    public PresenceOptions(string presenceKey, bool enabled = true)
+    {
+        this.PresenceKey = presenceKey;
+        this.Enabled = enabled;
+    }
 }

--- a/packages/Realtime/Realtime/Presence/PresenceOptions.cs
+++ b/packages/Realtime/Realtime/Presence/PresenceOptions.cs
@@ -24,8 +24,14 @@ public class PresenceOptions
     /// Presence options.
     /// </summary>
     /// <param name="presenceKey"></param>
+    public PresenceOptions(string presenceKey) => this.PresenceKey = presenceKey;
+
+    /// <summary>
+    /// Presence options.
+    /// </summary>
+    /// <param name="presenceKey"></param>
     /// <param name="enabled"></param>
-    public PresenceOptions(string presenceKey, bool enabled = true)
+    public PresenceOptions(string presenceKey, bool enabled)
     {
         this.PresenceKey = presenceKey;
         this.Enabled = enabled;

--- a/packages/Realtime/Realtime/PublicAPI.Unshipped.txt
+++ b/packages/Realtime/Realtime/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+*REMOVED*Supabase.Realtime.Presence.PresenceOptions.PresenceOptions(string! presenceKey) -> void
+Supabase.Realtime.Interfaces.IRealtimeChannel.Register<TPresenceResponse>(Supabase.Realtime.Presence.PresenceOptions! options) -> Supabase.Realtime.RealtimePresence<TPresenceResponse!>!
+Supabase.Realtime.Presence.PresenceOptions.Enabled.get -> bool
+Supabase.Realtime.Presence.PresenceOptions.Enabled.set -> void
+Supabase.Realtime.Presence.PresenceOptions.PresenceOptions(string! presenceKey, bool enabled = true) -> void
+Supabase.Realtime.RealtimeChannel.Register<TPresenceResponse>(Supabase.Realtime.Presence.PresenceOptions! options) -> Supabase.Realtime.RealtimePresence<TPresenceResponse!>!

--- a/packages/Realtime/Realtime/PublicAPI.Unshipped.txt
+++ b/packages/Realtime/Realtime/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 #nullable enable
-*REMOVED*Supabase.Realtime.Presence.PresenceOptions.PresenceOptions(string! presenceKey) -> void
 Supabase.Realtime.Interfaces.IRealtimeChannel.Register<TPresenceResponse>(Supabase.Realtime.Presence.PresenceOptions! options) -> Supabase.Realtime.RealtimePresence<TPresenceResponse!>!
 Supabase.Realtime.Presence.PresenceOptions.Enabled.get -> bool
 Supabase.Realtime.Presence.PresenceOptions.Enabled.set -> void
-Supabase.Realtime.Presence.PresenceOptions.PresenceOptions(string! presenceKey, bool enabled = true) -> void
+Supabase.Realtime.Presence.PresenceOptions.PresenceOptions(string! presenceKey, bool enabled) -> void
 Supabase.Realtime.RealtimeChannel.Register<TPresenceResponse>(Supabase.Realtime.Presence.PresenceOptions! options) -> Supabase.Realtime.RealtimePresence<TPresenceResponse!>!

--- a/packages/Realtime/Realtime/RealtimeChannel.cs
+++ b/packages/Realtime/Realtime/RealtimeChannel.cs
@@ -78,7 +78,7 @@ public class RealtimeChannel : IRealtimeChannel
     /// <summary>
     /// The saved Presence Options, set in <see cref="Register{TPresenceResponse}(string)"/> or <see cref="Register{TPresenceResponse}(PresenceOptions)"/>
     /// </summary>
-    public PresenceOptions? PresenceOptions { get; private set; } = new(string.Empty);
+    public PresenceOptions? PresenceOptions { get; private set; }
 
     /// <summary>
     /// The saved Postgres Changes Options, set in <see cref="Register(PostgresChanges.PostgresChangesOptions)"/>
@@ -248,7 +248,7 @@ public class RealtimeChannel : IRealtimeChannel
     /// </summary>
     /// <typeparam name="TPresenceResponse">The model representing a presence payload.</typeparam>
     /// <param name="options">The presence options to configure the channel's presence behavior.</param>
-    /// <returns></returns>
+    /// <returns>A <see cref="RealtimePresence{TPresenceResponse}"/> instance for managing presence state.</returns>
     /// <exception cref="InvalidOperationException">Thrown if called multiple times.</exception>
     public RealtimePresence<TPresenceResponse> Register<TPresenceResponse>(PresenceOptions options)
         where TPresenceResponse : BasePresence

--- a/packages/Realtime/Realtime/RealtimeChannel.cs
+++ b/packages/Realtime/Realtime/RealtimeChannel.cs
@@ -76,7 +76,7 @@ public class RealtimeChannel : IRealtimeChannel
     public BroadcastOptions? BroadcastOptions { get; private set; } = new();
 
     /// <summary>
-    /// The saved Presence Options, set in <see cref="Register{TPresenceResponse}(string)"/>
+    /// The saved Presence Options, set in <see cref="Register{TPresenceResponse}(string)"/> or <see cref="Register{TPresenceResponse}(PresenceOptions)"/>
     /// </summary>
     public PresenceOptions? PresenceOptions { get; private set; } = new(string.Empty);
 
@@ -240,14 +240,25 @@ public class RealtimeChannel : IRealtimeChannel
     /// <returns></returns>
     /// <exception cref="InvalidOperationException">Thrown if called multiple times.</exception>
     public RealtimePresence<TPresenceResponse> Register<TPresenceResponse>(string presenceKey)
+        where TPresenceResponse : BasePresence =>
+        this.Register<TPresenceResponse>(new PresenceOptions(presenceKey, enabled: true));
+
+    /// <summary>
+    /// Registers a <see cref="RealtimePresence{TPresenceResponse}"/> instance with the specified options.
+    /// </summary>
+    /// <typeparam name="TPresenceResponse">The model representing a presence payload.</typeparam>
+    /// <param name="options">The presence options to configure the channel's presence behavior.</param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">Thrown if called multiple times.</exception>
+    public RealtimePresence<TPresenceResponse> Register<TPresenceResponse>(PresenceOptions options)
         where TPresenceResponse : BasePresence
     {
         if (this.presence != null)
             throw new InvalidOperationException(
                 "Register can only be called with presence options for a channel once.");
 
-        this.PresenceOptions = new PresenceOptions(presenceKey);
-        var instance = new RealtimePresence<TPresenceResponse>(this, this.PresenceOptions, this.Options.SerializerSettings);
+        this.PresenceOptions = options;
+        var instance = new RealtimePresence<TPresenceResponse>(this, options, this.Options.SerializerSettings);
         this.presence = instance;
 
         this.PresenceSync = (_, response) => this.presence.TriggerSync(response);


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Adds the `enabled` flag to `PrescenceOptions`
- Adds a `Register` function variant to accept a `PrescenceOptions` input, alongside the existing `presenceKey` signature
- Removes the default `PrescenceOptions` value, starting as null (https://github.com/supabase-community/supabase-csharp/pull/407#issuecomment-5530001150)

## What is the current behavior?

When on latest Supabase, registering a presence will not pick up on the initial sync data. This is due to the `enabled` flag not being a part of the pre-existing `PrescenceOptions`.

## What is the new behavior?

The user now has the ability to explicitly add the `enabled` flag, fixing this issue.

## Additional context

Tested these changes on [Fortnite Porting](https://github.com/h4lfheart/FortnitePorting)'s chat feature. 

After updating my self-hosted Supabase instance to the latest verison, realtime stopped providing me the initial sync data which told the client of all currently online users (though it kept tracking new joins). After adding the enabled flag and setting it to true, the client has started receiving the initial online data again.