### PR TITLE
fix(postgrest): keep ! and unary minus on captured values in Where filters

### DIFF
--- a/packages/Postgrest/Postgrest.Tests/Linq/WhereClauseTests.cs
+++ b/packages/Postgrest/Postgrest.Tests/Linq/WhereClauseTests.cs
@@ -178,6 +178,45 @@ public class WhereClauseTests
         act.Should().Throw<ArgumentException>().WithMessage("*cannot compare two model columns*");
     }
 
+    [TestMethod]
+    public void Where_ShouldEvaluateANegatedCapturedBool()
+    {
+        var pending = true;
+        this.client.Table<Todo>().Where(x => x.Done == !pending)
+            .GenerateUrl().Should().Be($"{BaseUrl}/todos?done=eq.False");
+    }
+
+    [TestMethod]
+    public void Where_ShouldEvaluateAUnaryMinusOnACapturedInt()
+    {
+        var threshold = 100;
+        this.client.Table<Todo>().Where(x => x.UserId < -threshold)
+            .GenerateUrl().Should().Be($"{BaseUrl}/todos?user_id=lt.-100");
+    }
+
+    [TestMethod]
+    public void Where_ShouldUseTheEnumName_GivenAnEnumColumn()
+    {
+        this.client.Table<Movie>().Where(x => x.Status == MovieStatus.OnDisplay)
+            .GenerateUrl().Should().StartWith($"{BaseUrl}/movie?status=eq.OnDisplay&select=");
+    }
+
+    [TestMethod]
+    public void Where_ShouldKeepAnExplicitCast_GivenADoubleColumn()
+    {
+        var threshold = 100.9;
+        this.client.Table<KitchenSink>().Where(x => x.DoubleValue < (int)threshold)
+            .GenerateUrl().Should().Be($"{BaseUrl}/kitchen_sink?double_value=lt.100");
+    }
+
+    [TestMethod]
+    public void Where_ShouldKeepAnEnumToIntCast_GivenAnIntColumn()
+    {
+        var status = MovieStatus.OffDisplay;
+        this.client.Table<Todo>().Where(x => x.UserId == (int)status)
+            .GenerateUrl().Should().Be($"{BaseUrl}/todos?user_id=eq.1");
+    }
+
     private class UserRequestModel
     {
         public Func<User, bool>? FilterPredicate { get; set; }

--- a/packages/Postgrest/Postgrest/Linq/WhereExpressionVisitor.cs
+++ b/packages/Postgrest/Postgrest/Linq/WhereExpressionVisitor.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using Supabase.Postgrest.Attributes;
 using Supabase.Postgrest.Interfaces;
 using static Supabase.Postgrest.Constants;
@@ -119,14 +118,17 @@ namespace Supabase.Postgrest.Linq
             // Otherwise, the base case.
 
             string? column = null;
+            Type? columnType = null;
             if (node.Left is MemberExpression leftMember)
             {
                 column = GetColumnFromMemberExpression(leftMember);
+                columnType = leftMember.Type;
             } //To handle properly if it's a Convert ExpressionType generally with nullable properties
             else if (node.Left is UnaryExpression leftUnary && leftUnary.NodeType == ExpressionType.Convert &&
                      leftUnary.Operand is MemberExpression leftOperandMember)
             {
                 column = GetColumnFromMemberExpression(leftOperandMember);
+                columnType = leftOperandMember.Type;
             }
 
             if (column == null)
@@ -136,22 +138,12 @@ namespace Supabase.Postgrest.Linq
             if (ContainsParameter(node.Right))
                 throw new ArgumentException($"Unable to translate '{node}': Postgrest cannot compare two model columns to each other. Use a database computed/generated column or an RPC for column-to-column comparisons.");
 
-            if (node.Right is ConstantExpression rightConstantExpression)
-            {
-                HandleConstantExpression(column, op, rightConstantExpression);
-            }
-            else if (node.Right is MemberExpression memberExpression)
-            {
-                HandleMemberExpression(column, op, memberExpression);
-            }
-            else if (node.Right is NewExpression newExpression)
-            {
-                HandleNewExpression(column, op, newExpression);
-            }
-            else if (node.Right is UnaryExpression unaryExpression)
-            {
-                HandleUnaryExpression(column, op, unaryExpression);
-            }
+            // Enum columns are compared through the underlying int, so drop that cast to send the name.
+            var value = node.Right;
+            if (IsEnum(columnType!) && value is UnaryExpression { NodeType: ExpressionType.Convert } convert)
+                value = convert.Operand;
+
+            Filter = BuildFilter(column, op, EvaluateExpression(value));
 
             return node;
         }
@@ -339,26 +331,12 @@ namespace Supabase.Postgrest.Linq
             };
 
         /// <summary>
-        /// A constant expression parser (i.e. x => x.Id == 5 &lt;- where '5' is the constant)
+        /// True for an enum type, including a nullable enum.
         /// </summary>
-        /// <param name="column"></param>
-        /// <param name="op"></param>
-        /// <param name="constantExpression"></param>
-        private void HandleConstantExpression(string column, Operator op, ConstantExpression constantExpression)
-        {
-            Filter = BuildFilter(column, op, constantExpression.Value);
-        }
-
-        /// <summary>
-        /// A member expression parser (i.e. => x.Id == Example.Id &lt;- where both `x.Id` and `Example.Id` are parsed as 'members')
-        /// </summary>
-        /// <param name="column"></param>
-        /// <param name="op"></param>
-        /// <param name="memberExpression"></param>
-        private void HandleMemberExpression(string column, Operator op, MemberExpression memberExpression)
-        {
-            Filter = BuildFilter(column, op, GetMemberExpressionValue(memberExpression));
-        }
+        /// <param name="type"></param>
+        /// <returns></returns>
+        private static bool IsEnum(Type type) =>
+            (Nullable.GetUnderlyingType(type) ?? type).IsEnum;
 
         /// <summary>
         /// Builds a filter from a column, operator and (possibly null) criterion, translating null
@@ -380,70 +358,6 @@ namespace Supabase.Postgrest.Linq
                     new QueryFilter(column, Operator.Is, QueryFilter.NullVal)),
                 _ => new QueryFilter(column, op, value)
             };
-        }
-
-        /// <summary>
-        /// A unary expression parser (i.e. => x.Id == 1 &lt;- where both `1` is considered unary)
-        /// </summary>
-        /// <param name="column"></param>
-        /// <param name="op"></param>
-        /// <param name="unaryExpression"></param>
-        private void HandleUnaryExpression(string column, Operator op, UnaryExpression unaryExpression)
-        {
-            if (unaryExpression.Operand is ConstantExpression constantExpression)
-            {
-                HandleConstantExpression(column, op, constantExpression);
-            }
-            else if (unaryExpression.Operand is MemberExpression memberExpression)
-            {
-                HandleMemberExpression(column, op, memberExpression);
-            }
-            else if (unaryExpression.Operand is NewExpression newExpression)
-            {
-                HandleNewExpression(column, op, newExpression);
-            }
-        }
-
-        /// <summary>
-        /// An instantiated class parser (i.e. x => x.CreatedAt &lt;= new DateTime(2022, 08, 20) &lt;- where `new DateTime(...)` is an instantiated expression.
-        /// </summary>
-        /// <param name="column"></param>
-        /// <param name="op"></param>
-        /// <param name="newExpression"></param>
-        private void HandleNewExpression(string column, Operator op, NewExpression newExpression)
-        {
-            var argumentValues = new List<object>();
-            foreach (var argument in newExpression.Arguments)
-            {
-                var lambda = Expression.Lambda(argument);
-                var func = lambda.Compile();
-                argumentValues.Add(func.DynamicInvoke());
-            }
-
-            var constructor = newExpression.Constructor;
-            var instance = constructor.Invoke(argumentValues.ToArray());
-
-            switch (instance)
-            {
-                case DateTime dateTime:
-                    Filter = new QueryFilter(column, op, dateTime);
-                    break;
-                case DateTimeOffset dateTimeOffset:
-                    Filter = new QueryFilter(column, op, dateTimeOffset);
-                    break;
-                case Guid guid:
-                    Filter = new QueryFilter(column, op, guid.ToString());
-                    break;
-                default:
-                {
-                    if (instance.GetType().IsEnum)
-                    {
-                        Filter = new QueryFilter(column, op, instance);
-                    }
-
-                    break;
-                }
-            }
         }
 
         /// <summary>
@@ -471,24 +385,6 @@ namespace Supabase.Postgrest.Linq
             }
 
             return node.Member.Name;
-        }
-
-        /// <summary>
-        /// Get the value from a MemberExpression, which includes both fields and properties.
-        /// </summary>
-        /// <param name="member"></param>
-        /// <returns></returns>
-        private object GetMemberExpressionValue(MemberExpression member)
-        {
-            if (member.Member is FieldInfo field)
-            {
-                var obj = Expression.Lambda(member.Expression).Compile().DynamicInvoke();
-                return field.GetValue(obj);
-            }
-
-            var lambda = Expression.Lambda(member);
-            var func = lambda.Compile();
-            return func.DynamicInvoke();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #413

Right side of Where was handled by node type and `!` or unary minus on captured variable was ignored, so `x.Done == !keepActive` sent `done=eq.True`. Now right side is just evaluated. Enums still use name.
