### PR TITLE
feat(functions): stream edge function responses

### DIFF
--- a/packages/Core/Core/Http/RetryExecutor.cs
+++ b/packages/Core/Core/Http/RetryExecutor.cs
@@ -12,13 +12,18 @@ public static class RetryExecutor
     private static readonly ThreadLocal<Random> RandomProvider = new(() => new Random(Guid.NewGuid().GetHashCode()));
 
     /// <summary>Sends via <paramref name="requestFactory"/>, called fresh per attempt since a sent <see cref="HttpRequestMessage"/> can't be reused.</summary>
+    public static Task<HttpResponseMessage> SendAsync(HttpClient client, Func<HttpRequestMessage> requestFactory,
+        RetryOptions options, CancellationToken cancellationToken = default) =>
+        SendAsync(client, requestFactory, options, HttpCompletionOption.ResponseContentRead, cancellationToken);
+
+    /// <summary>Sends a request with the specified <paramref name="completionOption"/>.</summary>
     public static async Task<HttpResponseMessage> SendAsync(HttpClient client, Func<HttpRequestMessage> requestFactory,
-        RetryOptions options, CancellationToken cancellationToken = default)
+        RetryOptions options, HttpCompletionOption completionOption, CancellationToken cancellationToken)
     {
         var attempt = 0;
         while (true)
         {
-            var (response, exception) = await Attempt(client, requestFactory, cancellationToken).ConfigureAwait(false);
+            var (response, exception) = await Attempt(client, requestFactory, completionOption, cancellationToken).ConfigureAwait(false);
             if (!ShouldRetry(response, exception, attempt, options))
                 return response ?? throw exception!;
 
@@ -29,12 +34,12 @@ public static class RetryExecutor
     }
 
     private static async Task<(HttpResponseMessage? Response, HttpRequestException? Exception)> Attempt(
-        HttpClient client, Func<HttpRequestMessage> requestFactory, CancellationToken cancellationToken)
+        HttpClient client, Func<HttpRequestMessage> requestFactory, HttpCompletionOption completionOption, CancellationToken cancellationToken)
     {
         using var request = requestFactory();
         try
         {
-            return (await client.SendAsync(request, cancellationToken).ConfigureAwait(false), null);
+            return (await client.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false), null);
         }
         catch (HttpRequestException e)
         {

--- a/packages/Core/Core/PublicAPI.Unshipped.txt
+++ b/packages/Core/Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Supabase.Core.Http.RetryExecutor.SendAsync(System.Net.Http.HttpClient! client, System.Func<System.Net.Http.HttpRequestMessage!>! requestFactory, Supabase.Core.Http.RetryOptions! options, System.Net.Http.HttpCompletionOption completionOption, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!

--- a/packages/Functions/Functions.Tests/ClientContractTests.cs
+++ b/packages/Functions/Functions.Tests/ClientContractTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Supabase.Core.Http;
 using Supabase.Functions;
 using Supabase.Functions.Exceptions;
 using WireMock;
+using WireMock.Models;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -28,6 +30,7 @@ namespace Functions.Tests;
 public class ClientContractTests
 {
     private const string FunctionName = "hello";
+    private static readonly TimeSpan Deadline = TimeSpan.FromSeconds(5);
 
     private WireMockServer server = null!;
     private Client client = null!;
@@ -215,16 +218,8 @@ public class ClientContractTests
     [TestMethod]
     public async Task Invoke_ShouldRetryUntilSuccess_GivenRetryableStatus()
     {
-        this.client = new Client($"{this.server.Url}/functions/v1", options: new ClientOptions
-        {
-            Retry = new RetryOptions { MaxRetries = 1, BaseDelay = TimeSpan.FromMilliseconds(1) }
-        });
-        this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
-            .InScenario("retry").WillSetStateTo("retried")
-            .RespondWith(Response.Create().WithStatusCode(503));
-        this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
-            .InScenario("retry").WhenStateIs("retried")
-            .RespondWith(Response.Create().WithStatusCode(200).WithBody("recovered"));
+        this.client = this.RetryingClient();
+        this.RespondWithFailureThenSuccess();
 
         var result = await this.client.Invoke(FunctionName);
 
@@ -251,9 +246,103 @@ public class ClientContractTests
             "caller-triggered cancellation must not be mis-reported as an HttpTimeout");
     }
 
+    [TestMethod]
+    public async Task InvokeStream_ShouldReturnBeforeBodyCompletes()
+    {
+        var holdBodyOpen = new TaskCompletionSource();
+        this.RespondWithEvents(async queue =>
+        {
+            queue.Write("data: first\n\n");
+            await holdBodyOpen.Task;
+        });
+
+        try
+        {
+            using var response = await this.client.InvokeStream(FunctionName).WaitAsync(Deadline);
+            using var reader = new StreamReader(await response.Content.ReadAsStreamAsync());
+            (await reader.ReadLineAsync().WaitAsync(Deadline)).Should().Be("data: first");
+        }
+        finally
+        {
+            holdBodyOpen.TrySetResult();
+        }
+    }
+
+    [TestMethod]
+    public async Task InvokeStream_ShouldThrowFunctionsException_GivenServerError()
+    {
+        this.RespondWith(500, "internal boom");
+        var act = () => this.client.InvokeStream(FunctionName);
+        var exception = (await act.Should().ThrowAsync<FunctionsException>()).Which;
+        using (new AssertionScope())
+        {
+            exception.StatusCode.Should().Be(500);
+            exception.Content.Should().Be("internal boom");
+            (await exception.Response!.Content.ReadAsStringAsync()).Should().Be("internal boom");
+        }
+    }
+
+    [TestMethod]
+    public async Task InvokeStream_ShouldThrowTimeoutException_GivenRelayErrorBodyStallsPastHttpTimeout()
+    {
+        // WireMock SSE responses use status 200; mark this one as a relay error.
+        var holdBodyOpen = new TaskCompletionSource();
+        this.RespondWithEvents(async queue =>
+        {
+            queue.Write("partial");
+            await holdBodyOpen.Task;
+        }, Response.Create().WithHeader("x-relay-error", "true"));
+
+        try
+        {
+            var act = () => this.client.InvokeStream(FunctionName, options: new InvokeFunctionOptions { HttpTimeout = TimeSpan.FromMilliseconds(100) });
+            (await act.Should().ThrowAsync<TaskCanceledException>().WaitAsync(Deadline)).Which.InnerException.Should().BeOfType<TimeoutException>();
+        }
+        finally
+        {
+            holdBodyOpen.TrySetResult();
+        }
+    }
+
+    [TestMethod]
+    public async Task InvokeStream_ShouldRetryUntilSuccess_GivenRetryableStatus()
+    {
+        this.client = this.RetryingClient();
+        this.RespondWithFailureThenSuccess();
+
+        using var response = await this.client.InvokeStream(FunctionName);
+
+        (await response.Content.ReadAsStringAsync()).Should().Be("recovered");
+    }
+
     private void RespondWith(int statusCode, string body) =>
         this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
             .RespondWith(Response.Create().WithStatusCode(statusCode).WithHeader("Content-Type", "application/json").WithBody(body));
+
+    private Client RetryingClient() =>
+        new($"{this.server.Url}/functions/v1", options: new ClientOptions
+        {
+            Retry = new RetryOptions { MaxRetries = 1, BaseDelay = TimeSpan.FromMilliseconds(1) }
+        });
+
+    private void RespondWithFailureThenSuccess()
+    {
+        this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
+            .InScenario("retry").WillSetStateTo("retried")
+            .RespondWith(Response.Create().WithStatusCode(503));
+        this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
+            .InScenario("retry").WhenStateIs("retried")
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("recovered"));
+    }
+
+    private void RespondWithEvents(Func<IBlockingQueue<string?>, Task> body, IResponseBuilder? response = null) =>
+        this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
+            .RespondWith((response ?? Response.Create()).WithHeader("Content-Type", "text/event-stream")
+                .WithSseBody(async (_, queue) =>
+                {
+                    await body(queue);
+                    queue.Close();
+                }));
 
     private IRequestMessage SingleRequest() => this.server.LogEntries.Should().ContainSingle().Which.RequestMessage!;
 

--- a/packages/Functions/Functions.Tests/ClientContractTests.cs
+++ b/packages/Functions/Functions.Tests/ClientContractTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -218,8 +217,16 @@ public class ClientContractTests
     [TestMethod]
     public async Task Invoke_ShouldRetryUntilSuccess_GivenRetryableStatus()
     {
-        this.client = this.RetryingClient();
-        this.RespondWithFailureThenSuccess();
+        this.client = new Client($"{this.server.Url}/functions/v1", options: new ClientOptions
+        {
+            Retry = new RetryOptions { MaxRetries = 1, BaseDelay = TimeSpan.FromMilliseconds(1) }
+        });
+        this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
+            .InScenario("retry").WillSetStateTo("retried")
+            .RespondWith(Response.Create().WithStatusCode(503));
+        this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
+            .InScenario("retry").WhenStateIs("retried")
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("recovered"));
 
         var result = await this.client.Invoke(FunctionName);
 
@@ -256,84 +263,42 @@ public class ClientContractTests
             await holdBodyOpen.Task;
         });
 
-        try
-        {
-            using var response = await this.client.InvokeStream(FunctionName).WaitAsync(Deadline);
-            using var reader = new StreamReader(await response.Content.ReadAsStreamAsync());
-            (await reader.ReadLineAsync().WaitAsync(Deadline)).Should().Be("data: first");
-        }
-        finally
-        {
-            holdBodyOpen.TrySetResult();
-        }
+        using var response = await this.client.InvokeStream(FunctionName).WaitAsync(Deadline);
+        holdBodyOpen.SetResult();
+
+        (await response.Content.ReadAsStringAsync()).Should().Be("data: first\n\n");
     }
 
     [TestMethod]
-    public async Task InvokeStream_ShouldThrowFunctionsException_GivenServerError()
+    public async Task InvokeStream_ShouldBufferTheErrorBody_GivenServerError()
     {
         this.RespondWith(500, "internal boom");
         var act = () => this.client.InvokeStream(FunctionName);
         var exception = (await act.Should().ThrowAsync<FunctionsException>()).Which;
-        using (new AssertionScope())
-        {
-            exception.StatusCode.Should().Be(500);
-            exception.Content.Should().Be("internal boom");
-            (await exception.Response!.Content.ReadAsStringAsync()).Should().Be("internal boom");
-        }
+        (await exception.Response!.Content.ReadAsStringAsync()).Should().Be("internal boom");
     }
 
     [TestMethod]
-    public async Task InvokeStream_ShouldThrowTimeoutException_GivenRelayErrorBodyStallsPastHttpTimeout()
+    public async Task InvokeStream_ShouldThrowTimeoutException_GivenAStalledErrorBody()
     {
-        // WireMock SSE responses use status 200; mark this one as a relay error.
         var holdBodyOpen = new TaskCompletionSource();
+        // WireMock forces 200 on an SSE body, so a relay error is what makes this one fail.
         this.RespondWithEvents(async queue =>
         {
             queue.Write("partial");
             await holdBodyOpen.Task;
         }, Response.Create().WithHeader("x-relay-error", "true"));
 
-        try
-        {
-            var act = () => this.client.InvokeStream(FunctionName, options: new InvokeFunctionOptions { HttpTimeout = TimeSpan.FromMilliseconds(100) });
-            (await act.Should().ThrowAsync<TaskCanceledException>().WaitAsync(Deadline)).Which.InnerException.Should().BeOfType<TimeoutException>();
-        }
-        finally
-        {
-            holdBodyOpen.TrySetResult();
-        }
-    }
+        var act = () => this.client.InvokeStream(FunctionName, options: new InvokeFunctionOptions { HttpTimeout = TimeSpan.FromMilliseconds(100) });
+        var exception = (await act.Should().ThrowAsync<TaskCanceledException>().WaitAsync(Deadline)).Which;
+        holdBodyOpen.SetResult();
 
-    [TestMethod]
-    public async Task InvokeStream_ShouldRetryUntilSuccess_GivenRetryableStatus()
-    {
-        this.client = this.RetryingClient();
-        this.RespondWithFailureThenSuccess();
-
-        using var response = await this.client.InvokeStream(FunctionName);
-
-        (await response.Content.ReadAsStringAsync()).Should().Be("recovered");
+        exception.InnerException.Should().BeOfType<TimeoutException>();
     }
 
     private void RespondWith(int statusCode, string body) =>
         this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
             .RespondWith(Response.Create().WithStatusCode(statusCode).WithHeader("Content-Type", "application/json").WithBody(body));
-
-    private Client RetryingClient() =>
-        new($"{this.server.Url}/functions/v1", options: new ClientOptions
-        {
-            Retry = new RetryOptions { MaxRetries = 1, BaseDelay = TimeSpan.FromMilliseconds(1) }
-        });
-
-    private void RespondWithFailureThenSuccess()
-    {
-        this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
-            .InScenario("retry").WillSetStateTo("retried")
-            .RespondWith(Response.Create().WithStatusCode(503));
-        this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())
-            .InScenario("retry").WhenStateIs("retried")
-            .RespondWith(Response.Create().WithStatusCode(200).WithBody("recovered"));
-    }
 
     private void RespondWithEvents(Func<IBlockingQueue<string?>, Task> body, IResponseBuilder? response = null) =>
         this.server.Given(Request.Create().WithPath($"/functions/v1/{FunctionName}").UsingAnyMethod())

--- a/packages/Functions/Functions/Client.cs
+++ b/packages/Functions/Functions/Client.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -83,6 +84,27 @@ public partial class Client : IFunctionsClient
     }
 
     /// <summary>
+    /// Invokes a function and returns a successful response after its headers arrive.
+    /// <see cref="InvokeFunctionOptions.HttpTimeout"/> covers the request and any error body.
+    /// </summary>
+    /// <param name="functionName">Function name, appended to the base URL.</param>
+    /// <param name="token">Bearer token.</param>
+    /// <param name="options">Invocation options.</param>
+    /// <param name="cancellationToken">Cancels the request and error-body reads. Cancel successful body reads separately.</param>
+    /// <returns>The response, which the caller must dispose.</returns>
+    public Task<HttpResponseMessage> InvokeStream(
+        string functionName,
+        string? token = null,
+        InvokeFunctionOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var url = $"{this.baseUrl}/{functionName}";
+
+        return this.HandleRequest(functionName, url, token, options, cancellationToken, HttpCompletionOption.ResponseHeadersRead);
+    }
+
+    /// <summary>
     /// Invokes a function and returns the Text content of the response.
     /// </summary>
     /// <param name="functionName">Function Name, will be appended to BaseUrl</param>
@@ -136,6 +158,7 @@ public partial class Client : IFunctionsClient
     /// <param name="token"></param>
     /// <param name="options"></param>
     /// <param name="cancellationToken"></param>
+    /// <param name="completionOption"></param>
     /// <returns></returns>
     /// <exception cref="FunctionsException"></exception>
     private async Task<HttpResponseMessage> HandleRequest(
@@ -143,7 +166,8 @@ public partial class Client : IFunctionsClient
         string url,
         string? token = null,
         InvokeFunctionOptions? options = null,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead
     )
     {
         options ??= new InvokeFunctionOptions();
@@ -178,7 +202,7 @@ public partial class Client : IFunctionsClient
 
         try
         {
-            var response = await RetryExecutor.SendAsync(this.httpClient, () => BuildRequestMessage(options, uri), this.Options.Retry, linkedCts.Token);
+            var response = await RetryExecutor.SendAsync(this.httpClient, () => BuildRequestMessage(options, uri), this.Options.Retry, completionOption, linkedCts.Token);
             statusCode = (int) response.StatusCode;
             var isRelayError = response.Headers.Contains("x-relay-error");
             activity.SetHttpResponseTags(statusCode.Value);
@@ -199,7 +223,9 @@ public partial class Client : IFunctionsClient
                 errorType = statusCode.Value.ToString();
             }
 
-            var content = await response.Content.ReadAsStringAsync();
+            var content = completionOption == HttpCompletionOption.ResponseContentRead
+                ? await response.Content.ReadAsStringAsync()
+                : await BufferErrorBody(response, linkedCts.Token);
             var exception = new FunctionsException(content)
             {
                 Content = content,
@@ -226,6 +252,31 @@ public partial class Client : IFunctionsClient
         finally
         {
             FunctionsInstrumentation.RecordInvoke(options.HttpMethod, uri, functionName, statusCode, errorType, startTimestamp);
+        }
+    }
+
+    // Keep the error body readable through FunctionsException.Response.
+    private static async Task<string> BufferErrorBody(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var buffer = new MemoryStream();
+            var stream = await response.Content.ReadAsStreamAsync();
+            await stream.CopyToAsync(buffer, cancellationToken);
+
+            var buffered = new ByteArrayContent(buffer.ToArray());
+            foreach (var header in response.Content.Headers)
+                buffered.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+            response.Content.Dispose();
+            response.Content = buffered;
+
+            return await buffered.ReadAsStringAsync();
+        }
+        catch
+        {
+            response.Dispose();
+            throw;
         }
     }
 

--- a/packages/Functions/Functions/Client.cs
+++ b/packages/Functions/Functions/Client.cs
@@ -97,12 +97,7 @@ public partial class Client : IFunctionsClient
         string? token = null,
         InvokeFunctionOptions? options = null,
         CancellationToken cancellationToken = default
-    )
-    {
-        var url = $"{this.baseUrl}/{functionName}";
-
-        return this.HandleRequest(functionName, url, token, options, cancellationToken, HttpCompletionOption.ResponseHeadersRead);
-    }
+    ) => this.HandleRequest(functionName, $"{this.baseUrl}/{functionName}", token, options, cancellationToken, HttpCompletionOption.ResponseHeadersRead);
 
     /// <summary>
     /// Invokes a function and returns the Text content of the response.

--- a/packages/Functions/Functions/Interfaces/IFunctionsClient.cs
+++ b/packages/Functions/Functions/Interfaces/IFunctionsClient.cs
@@ -40,4 +40,14 @@ public interface IFunctionsClient : IGettableHeaders
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task<HttpContent> RawInvoke(string url, string? token = null, Client.InvokeFunctionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invokes a function and returns a successful response after its headers arrive.
+    /// </summary>
+    /// <param name="url">Function name, appended to the base URL.</param>
+    /// <param name="token">Bearer token.</param>
+    /// <param name="options">Invocation options.</param>
+    /// <param name="cancellationToken">Cancels the request and error-body reads. Cancel successful body reads separately.</param>
+    /// <returns>The response, which the caller must dispose.</returns>
+    Task<HttpResponseMessage> InvokeStream(string url, string? token = null, Client.InvokeFunctionOptions? options = null, CancellationToken cancellationToken = default);
 }

--- a/packages/Functions/Functions/PublicAPI.Unshipped.txt
+++ b/packages/Functions/Functions/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Supabase.Functions.Client.InvokeStream(string! functionName, string? token = null, Supabase.Functions.Client.InvokeFunctionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
+Supabase.Functions.Interfaces.IFunctionsClient.InvokeStream(string! url, string? token = null, Supabase.Functions.Client.InvokeFunctionOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!

--- a/packages/Functions/README.md
+++ b/packages/Functions/README.md
@@ -58,6 +58,19 @@ var options = new Client.InvokeFunctionOptions
 var result = await client.Invoke<MyResponse>("hello-world", token: SUPABASE_ANON_KEY, options);
 ```
 
+### Streaming a response
+
+`InvokeStream` returns successful responses after the headers arrive. `HttpTimeout` and request cancellation
+cover the request and error-body reads. Cancel successful body reads separately and dispose the response when finished.
+
+```csharp
+using var response = await client.InvokeStream("chat", token: SUPABASE_ANON_KEY);
+using var reader = new StreamReader(await response.Content.ReadAsStreamAsync());
+string? line;
+while ((line = await reader.ReadLineAsync()) != null)
+    Console.WriteLine(line);
+```
+
 ## Observability (OpenTelemetry)
 
 The client emits traces and metrics through `System.Diagnostics`, so you can wire them into

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -393,10 +393,10 @@ features:
     symbols:
       - InvokeFunctionOptions.HttpMethod
   functions.invocation.streaming_response:
-    status: partially_implemented
-    note: "RawInvoke returns raw HttpContent, but the request uses the default buffered completion (no incremental text/event-stream streaming)."
+    status: implemented
+    note: "InvokeStream returns response bodies for incremental reading."
     symbols:
-      - Client.RawInvoke
+      - Client.InvokeStream
   functions.invocation.region_selection:
     status: implemented
     note: "Full AWS region list; per-call override or client default; emits x-region."


### PR DESCRIPTION
Adds InvokeStream on the functions client. It returns the HttpResponseMessage once headers arrive, so a text/event-stream body can be read while the function is still writing. HttpTimeout and the caller token cover the request and any error body, the streamed body is the caller's to cancel and dispose.

RetryExecutor gets an overload taking HttpCompletionOption, the existing one forwards to it. An unread body is still disposed before a retry.

Adds a member to IFunctionsClient, custom implementations need to add it.

closes #416
