### PR TITLE
fix(postgrest): stop duplicating the package id in X-Client-Info

### DIFF
--- a/packages/Postgrest/Postgrest.Tests/Requests/RequestHeaderTests.cs
+++ b/packages/Postgrest/Postgrest.Tests/Requests/RequestHeaderTests.cs
@@ -59,6 +59,6 @@ public class RequestHeaderTests
     {
         var headers = Helpers.PrepareRequestHeaders(HttpMethod.Get);
         headers.Should().ContainKey("X-Client-Info")
-            .WhoseValue.Should().StartWith("postgrest-csharp/");
+            .WhoseValue.Should().StartWith("supabase.postgrest-csharp/");
     }
 }

--- a/packages/Postgrest/Postgrest/Helpers.cs
+++ b/packages/Postgrest/Postgrest/Helpers.cs
@@ -209,13 +209,13 @@ internal static class Helpers
             {
                 // Default version to match other clients
                 // https://github.com/search?q=org%3Asupabase-community+x-client-info&type=code
-                headers.Add("X-Client-Info", $"postgrest-csharp/{Util.GetAssemblyVersion(typeof(Client))}");
+                headers.Add("X-Client-Info", Util.GetAssemblyVersion(typeof(Client)));
             }
             catch (Exception)
             {
                 // Fallback for when the version can't be found
                 // e.g. running in the Unity Editor, ILL2CPP builds, etc.
-                headers.Add("X-Client-Info", $"postgrest-csharp/session-{AppSession}");
+                headers.Add("X-Client-Info", $"supabase.postgrest-csharp/session-{AppSession}");
             }
         }
 


### PR DESCRIPTION
## Problem

`Helpers.PrepareRequestHeaders` prefixed the shared header helper with a literal `postgrest-csharp/`:

```csharp
headers.Add("X-Client-Info", $"postgrest-csharp/{Util.GetAssemblyVersion(typeof(Client))}");
```

`Util.GetAssemblyVersion` ([Core/Util.cs:33](packages/Core/Core/Util.cs#L33)) already returns `{assemblyname-lowercased}-csharp/{version}{metadata}`. The emitted header was therefore:

```
postgrest-csharp/supabase.postgrest-csharp/8.0.0
```

The package id appears twice, and the value has three `/`-delimited segments instead of two. Any consumer that splits on `/` reads the version slot as `supabase.postgrest-csharp`.

## Scope

Postgrest was the only outlier. The other five call sites pass the helper through unmodified and are correct:

- `Storage/StorageBucketApi.cs:39`
- `Gotrue/Api.cs:43`
- `Functions/Client.cs:180`
- `Realtime/RealtimeSocket.cs:84`
- `Supabase/Client.cs:296`, `Supabase/StatelessClient.cs:167`

So the fix belongs in Postgrest, not in `Util`.

## Change

- Drop the redundant prefix; pass `Util.GetAssemblyVersion(typeof(Client))` through as-is.
- Fallback path (used when the version can't be resolved, e.g. Unity Editor / IL2CPP) keeps a package identifier but no longer duplicates it: `supabase.postgrest-csharp/session-{AppSession}`.
- `RequestHeaderTests.cs:62` asserted `StartWith("postgrest-csharp/")`. That passed only because of the bug — the assembly name is `Supabase.Postgrest`, so the corrected header starts with `supabase.postgrest-csharp/`. Updated to match, which mirrors `Functions.Tests/ClientContractTests.cs:116` (`supabase.functions-csharp/`).

## Impact

Confirmed against production telemetry (`supabase-etl-prod-eu.dbt.supabase_client_lib_requests`): this is the largest C# request bucket, roughly 648M requests/30d on v4 plus 31k on v8.

## Open item: downstream telemetry parsing

The header shape changes for every Postgrest request once this ships, so the dbt mart likely needs a compensating change:

- **New rows** emit two segments: `supabase.postgrest-csharp/8.x.x`.
- **Historical rows** (the ~648M/30d bucket) emit three: `postgrest-csharp/supabase.postgrest-csharp/4.x.x`.

If the mart splits on `/` and takes index 1 as the version, it will keep mis-parsing history and start parsing new rows correctly — so a period of mixed shapes needs handling either way. A parser that takes the **last** `/`-delimited segment as the version, or that strips a leading `postgrest-csharp/` when a second `-csharp/` segment follows, handles both.

I could not verify the actual model: the only accessible dbt repo (`supabase/dbt`) is private and archived since 2023, and does not contain a `supabase_client_lib_requests` model. **Someone with access to the live mart should confirm before this is released.**

## Testing

Not run locally — no .NET SDK on this machine. CI covers `Postgrest.Tests`.