### PR TITLE
feat(gotrue): add resend api to request confirmation code

### DIFF
--- a/packages/Gotrue/Gotrue.Tests/Authentication/ResendTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Authentication/ResendTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Threading.Tasks;
+using Gotrue.Tests.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Gotrue;
+using static Gotrue.Tests.TestUtils;
+
+namespace Gotrue.Tests.Authentication;
+
+[TestClass]
+[TestCategory("E2E")]
+public class ResendTests : AuthClientFixture
+{
+    [TestMethod]
+    public async Task Resend_ShouldRequestConfirmationCode_GivenSignUpType()
+    {
+        var email = RandomEmail();
+        var resend = new ResendParam(Constants.ResendType.SignUp) { Email = email };
+        var response = await this.Client.Resend(resend);
+
+        Assert.IsNotNull(response);
+        Assert.AreEqual(HttpStatusCode.OK, response?.ResponseMessage?.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Resend_ShouldRequestConfirmationCode_GivenSmsType()
+    {
+        var resend = new ResendParam(Constants.ResendType.Sms) { Phone = "5544989899898" };
+        var response = await this.Client.Resend(resend);
+
+        Assert.IsNotNull(response);
+        Assert.AreEqual(HttpStatusCode.OK, response?.ResponseMessage?.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Resend_ShouldRequestConfirmationCode_GivenPhoneChangeType()
+    {
+        var resend = new ResendParam(Constants.ResendType.PhoneChange) { Phone = "5544989899898" };
+        var response = await this.Client.Resend(resend);
+
+        Assert.IsNotNull(response);
+        Assert.AreEqual(HttpStatusCode.OK, response?.ResponseMessage?.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Resend_ShouldRequestConfirmationCode_GivenEmailChangeType()
+    {
+        var resend = new ResendParam(Constants.ResendType.EmailChange) { Email = RandomEmail() };
+        var response = await this.Client.Resend(resend);
+
+        Assert.IsNotNull(response);
+        Assert.AreEqual(HttpStatusCode.OK, response?.ResponseMessage?.StatusCode);
+    }
+}

--- a/packages/Gotrue/Gotrue/Api.cs
+++ b/packages/Gotrue/Gotrue/Api.cs
@@ -832,4 +832,16 @@ public class Api : IGotrueApi<User, Session>
 
         return this.MakeRequestAsync<Session>(HttpMethod.Post, $"{this.Url}/token?grant_type=refresh_token", data, this.Headers.MergeLeft(headers));
     }
+
+    /// <summary>
+    /// Resends a confirmation code to a user's email or phone.
+    /// </summary>
+    /// <param name="resend"></param>
+    /// <returns>BaseResponse</returns>
+    public Task<BaseResponse> Resend(ResendParam resend) => this.MakeRequestAsync(
+        HttpMethod.Post,
+        $"{this.Url}/resend",
+        resend,
+        this.Headers
+    );
 }

--- a/packages/Gotrue/Gotrue/Client.cs
+++ b/packages/Gotrue/Gotrue/Client.cs
@@ -13,6 +13,7 @@ using Supabase.Core.Http;
 using Supabase.Gotrue.Exceptions;
 using Supabase.Gotrue.Interfaces;
 using Supabase.Gotrue.Mfa;
+using Supabase.Gotrue.Responses;
 using static Supabase.Gotrue.Constants;
 using static Supabase.Gotrue.Constants.AuthState;
 using static Supabase.Gotrue.Exceptions.FailureHint.Reason;
@@ -946,6 +947,9 @@ public class Client : IGotrueClient<User, Session>
 
     /// <inheritdoc />
     public void Shutdown() => this.NotifyAuthStateChange(AuthState.Shutdown);
+
+    /// <inheritdoc />
+    public Task<BaseResponse> Resend(ResendParam resend) => this.api.Resend(resend);
 
     /// <inheritdoc />
     public async Task<MfaEnrollResponse?> Enroll(MfaEnrollParams mfaEnrollParams)

--- a/packages/Gotrue/Gotrue/Constants.cs
+++ b/packages/Gotrue/Gotrue/Constants.cs
@@ -1,167 +1,224 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Supabase.Core.Attributes;
 
 #pragma warning disable CS1591
 
-namespace Supabase.Gotrue
+namespace Supabase.Gotrue;
+
+/// <summary>
+/// Constants used throughout the Gotrue Client
+/// </summary>
+public static class Constants
 {
-	/// <summary>
-	/// Constants used throughout the Gotrue Client
-	/// </summary>
-	public static class Constants
-	{
-		/// <summary>
-		/// URL for the Gotrue server. Defaults to localhost:9999.
-		/// </summary>
-		public const string GOTRUE_URL = "http://localhost:9999";
-		public const string AUDIENCE = "";
-		public const int EXPIRY_MARGIN = 60 * 1000;
-		public const string STORAGE_KEY = "supabase.auth.token";
-		public static readonly Dictionary<string, object> CookieOptions = new Dictionary<string, object>
-		{
-			{ "name", "sb:token" },
-			{ "lifetime", 60 * 60 * 8 },
-			{ "domain", "" },
-			{ "path", "/" },
-			{ "sameSite", "lax" }
-		};
+    /// <summary>
+    /// URL for the Gotrue server. Defaults to localhost:9999.
+    /// </summary>
+    public const string GOTRUE_URL = "http://localhost:9999";
+    public const string AUDIENCE = "";
+    public const int EXPIRY_MARGIN = 60 * 1000;
+    public const string STORAGE_KEY = "supabase.auth.token";
+    public static readonly Dictionary<string, object> CookieOptions = new Dictionary<string, object>
+    {
+        { "name", "sb:token" },
+        { "lifetime", 60 * 60 * 8 },
+        { "domain", "" },
+        { "path", "/" },
+        { "sameSite", "lax" },
+    };
 
-		public enum SortOrder
-		{
-			[MapTo("asc")]
-			Ascending,
-			[MapTo("desc")]
-			Descending
-		}
+    public enum SortOrder
+    {
+        [MapTo("asc")]
+        Ascending,
 
-		public enum MobileOtpType
-		{
-			[MapTo("sms")]
-			SMS,
-			[MapTo("phone_change")]
-			PhoneChange
-		}
+        [MapTo("desc")]
+        Descending,
+    }
 
-		public enum EmailOtpType
-		{
-			[MapTo("signup")]
-			Signup,
-			[MapTo("invite")]
-			Invite,
-			[MapTo("magiclink")]
-			MagicLink,
-			[MapTo("recovery")]
-			Recovery,
-			[MapTo("email_change")]
-			EmailChange,
-			[MapTo("email")]
-			Email
-		}
+    public enum MobileOtpType
+    {
+        [MapTo("sms")]
+        SMS,
 
-		/// <summary>
-		/// Providers available to Supabase
-		/// Ref: https://supabase.github.io/gotrue-js/modules.html#Provider
-		/// </summary>
-		public enum Provider
-		{
-			[MapTo("anonymous_users")]
-			AnonymousUsers,
-			[MapTo("apple")]
-			Apple,
-			[MapTo("azure")]
-			Azure,
-			[MapTo("bitbucket")]
-			Bitbucket,
-			[MapTo("discord")]
-			Discord,
-			[MapTo("facebook")]
-			Facebook,
-			[MapTo("figma")]
-			Figma,
-			[MapTo("fly")]
-			Fly,
-			[MapTo("github")]
-			Github,
-			[MapTo("gitlab")]
-			Gitlab,
-			[MapTo("google")]
-			Google,
-			[MapTo("kakao")]
-			Kakao,
-			[MapTo("keycloak")]
-			KeyCloak,
-			[MapTo("linkedin")]
-			LinkedIn,
-			[MapTo("linkedin_oidc")]
-			LinkedInOIDC,
-			[MapTo("notion")]
-			Notion,
-			[MapTo("slack")]
-			Slack,
-			[MapTo("spotify")]
-			Spotify,
-			[MapTo("twitch")]
-			Twitch,
-			[MapTo("twitter")]
-			Twitter,
-			[MapTo("workos")]
-			WorkOS,
-			[MapTo("zoom")]
-			Zoom
-		}
+        [MapTo("phone_change")]
+        PhoneChange,
+    }
 
-		/// <summary>
-		/// States that the Auth Client will raise events for.
-		/// </summary>
-		public enum AuthState
-		{
-			SignedIn,
-			SignedOut,
-			UserUpdated,
-			PasswordRecovery,
-			TokenRefreshed,
-			Shutdown,
-			MfaChallengeVerified
-		}
+    public enum EmailOtpType
+    {
+        [MapTo("signup")]
+        Signup,
 
-		/// <summary>
-		/// Specifies the functionality expected from the `SignIn` method
-		/// </summary>
-		public enum SignInType
-		{
-			Email,
-			Phone,
-			RefreshToken
-		}
+        [MapTo("invite")]
+        Invite,
 
-		/// <summary>
-		/// Represents an OAuth Flow type
-		/// </summary>
-		public enum OAuthFlowType
-		{
-			[MapTo("implicit")]
-			Implicit,
-			[MapTo("pkce")]
-			PKCE
-		}
+        [MapTo("magiclink")]
+        MagicLink,
 
-		/// <summary>
-		/// Specifies the functionality expected from the `SignUp` method
-		/// </summary>
-		public enum SignUpType
-		{
-			Email,
-			Phone
-		}
+        [MapTo("recovery")]
+        Recovery,
 
-        public enum SignOutScope
-        {
-            [MapTo("global")]
-            Global,
-            [MapTo("local")]
-            Local,
-            [MapTo("others")]
-            Others
-        }
+        [MapTo("email_change")]
+        EmailChange,
+
+        [MapTo("email")]
+        Email,
+    }
+
+    /// <summary>
+    /// Providers available to Supabase
+    /// Ref: https://supabase.github.io/gotrue-js/modules.html#Provider
+    /// </summary>
+    public enum Provider
+    {
+        [MapTo("anonymous_users")]
+        AnonymousUsers,
+
+        [MapTo("apple")]
+        Apple,
+
+        [MapTo("azure")]
+        Azure,
+
+        [MapTo("bitbucket")]
+        Bitbucket,
+
+        [MapTo("discord")]
+        Discord,
+
+        [MapTo("facebook")]
+        Facebook,
+
+        [MapTo("figma")]
+        Figma,
+
+        [MapTo("fly")]
+        Fly,
+
+        [MapTo("github")]
+        Github,
+
+        [MapTo("gitlab")]
+        Gitlab,
+
+        [MapTo("google")]
+        Google,
+
+        [MapTo("kakao")]
+        Kakao,
+
+        [MapTo("keycloak")]
+        KeyCloak,
+
+        [MapTo("linkedin")]
+        LinkedIn,
+
+        [MapTo("linkedin_oidc")]
+        LinkedInOIDC,
+
+        [MapTo("notion")]
+        Notion,
+
+        [MapTo("slack")]
+        Slack,
+
+        [MapTo("spotify")]
+        Spotify,
+
+        [MapTo("twitch")]
+        Twitch,
+
+        [MapTo("twitter")]
+        Twitter,
+
+        [MapTo("workos")]
+        WorkOS,
+
+        [MapTo("zoom")]
+        Zoom,
+    }
+
+    /// <summary>
+    /// States that the Auth Client will raise events for.
+    /// </summary>
+    public enum AuthState
+    {
+        SignedIn,
+        SignedOut,
+        UserUpdated,
+        PasswordRecovery,
+        TokenRefreshed,
+        Shutdown,
+        MfaChallengeVerified,
+    }
+
+    /// <summary>
+    /// Specifies the functionality expected from the `SignIn` method
+    /// </summary>
+    public enum SignInType
+    {
+        Email,
+        Phone,
+        RefreshToken,
+    }
+
+    /// <summary>
+    /// Represents an OAuth Flow type
+    /// </summary>
+    public enum OAuthFlowType
+    {
+        [MapTo("implicit")]
+        Implicit,
+
+        [MapTo("pkce")]
+        PKCE,
+    }
+
+    /// <summary>
+    /// Specifies the functionality expected from the `SignUp` method
+    /// </summary>
+    public enum SignUpType
+    {
+        Email,
+        Phone,
+    }
+
+    public enum SignOutScope
+    {
+        [MapTo("global")]
+        Global,
+
+        [MapTo("local")]
+        Local,
+
+        [MapTo("others")]
+        Others,
+    }
+
+    /// <summary>
+    ///     The type of resend.
+    /// </summary>
+    public enum ResendType
+    {
+        /// <summary>Signup resend.</summary>
+        [MapTo("signup")]
+        [EnumMember(Value = "signup")]
+        SignUp,
+
+        /// <summary>SMS resend.</summary>
+        [MapTo("sms")]
+        [EnumMember(Value = "sms")]
+        Sms,
+
+        /// <summary>Phone change resend.</summary>
+        [MapTo("phone_change")]
+        [EnumMember(Value = "phone_change")]
+        PhoneChange,
+
+        /// <summary>Email change resend.</summary>
+        [MapTo("email_change")]
+        [EnumMember(Value = "email_change")]
+        EmailChange,
     }
 }

--- a/packages/Gotrue/Gotrue/Interfaces/IGotrueApi.cs
+++ b/packages/Gotrue/Gotrue/Interfaces/IGotrueApi.cs
@@ -81,4 +81,11 @@ public interface IGotrueApi<TUser, TSession> : IGettableHeaders
     /// <param name="userIdentity">Identity to be unlinked</param>
     /// <returns></returns>
     Task<bool> UnlinkIdentity(string token, UserIdentity userIdentity);
+
+    /// <summary>
+    /// Resends a confirmation code to a user's email or phone.
+    /// </summary>
+    /// <param name="resend"></param>
+    /// <returns></returns>
+    Task<BaseResponse> Resend(ResendParam resend);
 }

--- a/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
+++ b/packages/Gotrue/Gotrue/Interfaces/IGotrueClient.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Supabase.Core.Interfaces;
 using Supabase.Gotrue.Exceptions;
 using Supabase.Gotrue.Mfa;
+using Supabase.Gotrue.Responses;
 using static Supabase.Gotrue.Constants;
 
 #endregion
@@ -531,6 +532,13 @@ public interface IGotrueClient<TUser, TSession> : IGettableHeaders
     /// <param name="accessToken">The access token to send as the bearer authorization.</param>
     /// <param name="refreshToken">The refresh token to exchange for a new session.</param>
     Task RefreshToken(string accessToken, string refreshToken);
+
+    /// <summary>
+    /// Resends a confirmation code to a user's email or phone.
+    /// </summary>
+    /// <param name="resend"></param>
+    /// <returns></returns>
+    Task<BaseResponse> Resend(ResendParam resend);
 
     #region MFA
 

--- a/packages/Gotrue/Gotrue/PublicAPI.Unshipped.txt
+++ b/packages/Gotrue/Gotrue/PublicAPI.Unshipped.txt
@@ -9,4 +9,12 @@ Supabase.Gotrue.Constants.ResendType.Sms = 1 -> Supabase.Gotrue.Constants.Resend
 Supabase.Gotrue.Interfaces.IGotrueApi<TUser, TSession>.Resend(Supabase.Gotrue.ResendParam! resend) -> System.Threading.Tasks.Task<Supabase.Gotrue.Responses.BaseResponse!>!
 Supabase.Gotrue.Interfaces.IGotrueClient<TUser, TSession>.Resend(Supabase.Gotrue.ResendParam! resend) -> System.Threading.Tasks.Task<Supabase.Gotrue.Responses.BaseResponse!>!
 Supabase.Gotrue.ResendParam
+Supabase.Gotrue.ResendParam.Email.get -> string?
+Supabase.Gotrue.ResendParam.Email.set -> void
+Supabase.Gotrue.ResendParam.Options.get -> Supabase.Gotrue.ResendOptionsParam?
+Supabase.Gotrue.ResendParam.Options.set -> void
+Supabase.Gotrue.ResendParam.Phone.get -> string?
+Supabase.Gotrue.ResendParam.Phone.set -> void
 Supabase.Gotrue.ResendParam.ResendParam(Supabase.Gotrue.Constants.ResendType type) -> void
+Supabase.Gotrue.ResendParam.Type.get -> string?
+Supabase.Gotrue.ResendParam.Type.set -> void

--- a/packages/Gotrue/Gotrue/PublicAPI.Unshipped.txt
+++ b/packages/Gotrue/Gotrue/PublicAPI.Unshipped.txt
@@ -8,6 +8,12 @@ Supabase.Gotrue.Constants.ResendType.SignUp = 0 -> Supabase.Gotrue.Constants.Res
 Supabase.Gotrue.Constants.ResendType.Sms = 1 -> Supabase.Gotrue.Constants.ResendType
 Supabase.Gotrue.Interfaces.IGotrueApi<TUser, TSession>.Resend(Supabase.Gotrue.ResendParam! resend) -> System.Threading.Tasks.Task<Supabase.Gotrue.Responses.BaseResponse!>!
 Supabase.Gotrue.Interfaces.IGotrueClient<TUser, TSession>.Resend(Supabase.Gotrue.ResendParam! resend) -> System.Threading.Tasks.Task<Supabase.Gotrue.Responses.BaseResponse!>!
+Supabase.Gotrue.ResendOptionsParam
+Supabase.Gotrue.ResendOptionsParam.CaptchaToken.get -> string?
+Supabase.Gotrue.ResendOptionsParam.CaptchaToken.set -> void
+Supabase.Gotrue.ResendOptionsParam.EmailRedirectTo.get -> string?
+Supabase.Gotrue.ResendOptionsParam.EmailRedirectTo.set -> void
+Supabase.Gotrue.ResendOptionsParam.ResendOptionsParam() -> void
 Supabase.Gotrue.ResendParam
 Supabase.Gotrue.ResendParam.Email.get -> string?
 Supabase.Gotrue.ResendParam.Email.set -> void

--- a/packages/Gotrue/Gotrue/PublicAPI.Unshipped.txt
+++ b/packages/Gotrue/Gotrue/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Supabase.Gotrue.ResendParam.ResendParam(Supabase.Gotrue.Constants.ResendType type) -> void

--- a/packages/Gotrue/Gotrue/PublicAPI.Unshipped.txt
+++ b/packages/Gotrue/Gotrue/PublicAPI.Unshipped.txt
@@ -1,2 +1,12 @@
 #nullable enable
+Supabase.Gotrue.Api.Resend(Supabase.Gotrue.ResendParam! resend) -> System.Threading.Tasks.Task<Supabase.Gotrue.Responses.BaseResponse!>!
+Supabase.Gotrue.Client.Resend(Supabase.Gotrue.ResendParam! resend) -> System.Threading.Tasks.Task<Supabase.Gotrue.Responses.BaseResponse!>!
+Supabase.Gotrue.Constants.ResendType
+Supabase.Gotrue.Constants.ResendType.EmailChange = 3 -> Supabase.Gotrue.Constants.ResendType
+Supabase.Gotrue.Constants.ResendType.PhoneChange = 2 -> Supabase.Gotrue.Constants.ResendType
+Supabase.Gotrue.Constants.ResendType.SignUp = 0 -> Supabase.Gotrue.Constants.ResendType
+Supabase.Gotrue.Constants.ResendType.Sms = 1 -> Supabase.Gotrue.Constants.ResendType
+Supabase.Gotrue.Interfaces.IGotrueApi<TUser, TSession>.Resend(Supabase.Gotrue.ResendParam! resend) -> System.Threading.Tasks.Task<Supabase.Gotrue.Responses.BaseResponse!>!
+Supabase.Gotrue.Interfaces.IGotrueClient<TUser, TSession>.Resend(Supabase.Gotrue.ResendParam! resend) -> System.Threading.Tasks.Task<Supabase.Gotrue.Responses.BaseResponse!>!
+Supabase.Gotrue.ResendParam
 Supabase.Gotrue.ResendParam.ResendParam(Supabase.Gotrue.Constants.ResendType type) -> void

--- a/packages/Gotrue/Gotrue/ResendOptionsParam.cs
+++ b/packages/Gotrue/Gotrue/ResendOptionsParam.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace Supabase.Gotrue;
+
+/// <summary>
+/// Represents optional parameters used in the Resend API. These parameters provide
+/// additional customization for the resend operation, such as including a CAPTCHA
+/// token or specifying a redirection URL after email confirmation.
+/// </summary>
+public class ResendOptionsParam
+{
+    /// <summary>
+    /// Verification token received when the user completes the captcha on the site.
+    /// </summary>
+    [JsonPropertyName("captchaToken")]
+    public string? CaptchaToken { get; set; }
+
+    /// <summary>
+    /// A URL or mobile address to send the user to after they are confirmed.
+    /// </summary>
+    [JsonPropertyName("emailRedirectTo")]
+    public string? EmailRedirectTo { get; set; }
+}

--- a/packages/Gotrue/Gotrue/ResendParam.cs
+++ b/packages/Gotrue/Gotrue/ResendParam.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Supabase.Gotrue;
+
+/// <summary>
+/// Parameters for the Resend API.
+/// </summary>
+public class ResendParam
+{
+    /// <summary>
+    /// The email address to resend to.
+    /// </summary>
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// The phone number to resend to.
+    /// </summary>
+    [JsonPropertyName("phone")]
+    public string? Phone { get; set; }
+
+    /// <summary>
+    /// The type of resend.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    /// <summary>
+    /// Verification token received when the user completes the captcha on the site.
+    /// </summary>
+    [JsonPropertyName("captchaToken")]
+    public string? CaptchaToken { get; set; }
+
+    /// <summary>
+    /// A URL or mobile address to send the user to after they are confirmed.
+    /// </summary>
+    [JsonPropertyName("redirectTo")]
+    public string? RedirectTo { get; set; }
+
+    /// <summary>
+    /// A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public Dictionary<string, object>? Data { get; set; }
+
+    /// <summary>
+    /// Represents the parameters used for the Resend API, allowing for resending
+    /// confirmation codes or links based on the provided inputs. This includes
+    /// support for email, phone, and custom data.
+    /// </summary>
+    public ResendParam(Constants.ResendType type) => this.Type = Core.Helpers.GetMappedToAttr(type).Mapping;
+}

--- a/packages/Gotrue/Gotrue/ResendParam.cs
+++ b/packages/Gotrue/Gotrue/ResendParam.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Supabase.Gotrue;
@@ -27,27 +26,17 @@ public class ResendParam
     public string? Type { get; set; }
 
     /// <summary>
-    /// Verification token received when the user completes the captcha on the site.
+    /// Additional options to customize the behavior of the Resend API.
+    /// Provides support for features such as CAPTCHA tokens and email redirection.
     /// </summary>
-    [JsonPropertyName("captchaToken")]
-    public string? CaptchaToken { get; set; }
-
-    /// <summary>
-    /// A URL or mobile address to send the user to after they are confirmed.
-    /// </summary>
-    [JsonPropertyName("redirectTo")]
-    public string? RedirectTo { get; set; }
-
-    /// <summary>
-    /// A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
-    /// </summary>
-    [JsonPropertyName("data")]
-    public Dictionary<string, object>? Data { get; set; }
+    [JsonPropertyName("options")]
+    public ResendOptionsParam? Options { get; set; }
 
     /// <summary>
     /// Represents the parameters used for the Resend API, allowing for resending
     /// confirmation codes or links based on the provided inputs. This includes
     /// support for email, phone, and custom data.
     /// </summary>
-    public ResendParam(Constants.ResendType type) => this.Type = Core.Helpers.GetMappedToAttr(type).Mapping;
+    public ResendParam(Constants.ResendType type) =>
+        this.Type = Core.Helpers.GetMappedToAttr(type).Mapping;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?


## What is the new behavior?

- add resend request to get  confirmation code by type

## Additional context

- missing parity
