### PR TITLE
chore: bump Microsoft.SourceLink.GitHub to 10.0.303

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
     <PackageVersion Include="Websocket.Client" Version="5.5.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.303" />
     <!-- Test dependencies -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />


### PR DESCRIPTION
SourceLink 10.0.301 pulls in Microsoft.Build.Tasks.Git 10.0.301, which got flagged by GHSA-23fw-v26w-5fgq yesterday, so the gate's vulnerability check fails on every PR now. 10.0.303 fixes it, scan is clean after the bump.