### PR TITLE
fix(postgrest): keep the test of a ternary in Where filters

### DIFF
--- a/packages/Postgrest/Postgrest.Tests/Linq/WhereClauseTests.cs
+++ b/packages/Postgrest/Postgrest.Tests/Linq/WhereClauseTests.cs
@@ -217,6 +217,28 @@ public class WhereClauseTests
             .GenerateUrl().Should().Be($"{BaseUrl}/todos?user_id=eq.1");
     }
 
+    [TestMethod]
+    public void Where_ShouldKeepTheTest_GivenATernaryWithAFalseThenBranch()
+    {
+        this.client.Table<KitchenSink>().Where(x => x.BooleanValue ? false : x.IntValue > 3)
+            .GenerateUrl().Should().Be($"{BaseUrl}/kitchen_sink?and=(bool_value.not.eq.True%2cint_value.gt.3)");
+    }
+
+    [TestMethod]
+    public void Where_ShouldKeepTheTest_GivenATernaryWithAFalseElseBranch()
+    {
+        this.client.Table<KitchenSink>().Where(x => x.BooleanValue ? x.IntValue > 3 : false)
+            .GenerateUrl().Should().Be($"{BaseUrl}/kitchen_sink?and=(bool_value.eq.True%2cint_value.gt.3)");
+    }
+
+    [TestMethod]
+    public void Where_ShouldTranslateTernaryIntoOrOfAnds_GivenTwoColumnBranches()
+    {
+        this.client.Table<KitchenSink>().Where(x => x.BooleanValue ? x.IntValue > 3 : x.StringValue == "foo")
+            .GenerateUrl().Should()
+            .Be($"{BaseUrl}/kitchen_sink?or=(and(bool_value.eq.True%2cint_value.gt.3)%2cand(bool_value.not.eq.True%2cstring_value.eq.foo))");
+    }
+
     private class UserRequestModel
     {
         public Func<User, bool>? FilterPredicate { get; set; }

--- a/packages/Postgrest/Postgrest/Linq/WhereExpressionVisitor.cs
+++ b/packages/Postgrest/Postgrest/Linq/WhereExpressionVisitor.cs
@@ -171,6 +171,17 @@ internal class WhereExpressionVisitor : ExpressionVisitor
     }
 
     /// <summary>
+    /// Handles a ternary (i.e. `x => x.IsProtected ? false : x.IsExpired`), visited as
+    /// `(test &amp;&amp; a) || (!test &amp;&amp; b)` so the test is kept.
+    /// </summary>
+    /// <param name="node"></param>
+    /// <returns></returns>
+    protected override Expression VisitConditional(ConditionalExpression node) =>
+        this.Visit(Expression.OrElse(
+            Expression.AndAlso(node.Test, node.IfTrue),
+            Expression.AndAlso(Expression.Not(node.Test), node.IfFalse)));
+
+    /// <summary>
     /// Handles a boolean column used directly as a predicate (i.e. `x => x.IsActive`, or negated via
     /// <see cref="VisitUnary"/> `x => !x.IsActive`), translating it into a `column.eq.true` filter.
     /// </summary>


### PR DESCRIPTION
Fixes #415

Where had no VisitConditional so a ternary dropped its test. Now visited as (test && a) || (!test && b).