### PR TITLE
fix(gotrue): stop copying the user token into the apikey header

### DIFF
--- a/packages/Gotrue/Gotrue.Tests/Admin/AdminApiKeyHeaderContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Admin/AdminApiKeyHeaderContractTests.cs
@@ -25,6 +25,12 @@ public class AdminApiKeyHeaderContractTests
     private const string ServiceKey = "sb_secret_service_role_key";
     private const string UserId = "user-123";
 
+    // JWT-shaped test token; no valid signature needed.
+    private const string UserToken =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+        "eyJzdWIiOiJ1c2VyLTEyMyIsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjoyMDAwMDAwMDAwfQ." +
+        "not-a-real-signature";
+
     private MockGotrueServer server = null!;
 
     [TestInitialize]
@@ -32,6 +38,8 @@ public class AdminApiKeyHeaderContractTests
     {
         this.server = new MockGotrueServer();
         this.server.Given(Request.Create().WithPath($"/admin/users/{UserId}").UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody("{}"));
+        this.server.Given(Request.Create().WithPath("/user").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody("{}"));
     }
 
@@ -74,5 +82,16 @@ public class AdminApiKeyHeaderContractTests
         });
         await admin.DeleteUser(UserId);
         this.server.VerifySingleReceivedRequest().WithHeader("apiKey", "project-anon-key");
+    }
+
+    [TestMethod]
+    public async Task GetUser_ShouldNotSendUserTokenAsApiKey_GivenNoApiKeyConfigured()
+    {
+        // Copying a user token into apikey caused a 401 (#424).
+        var admin = new AdminClient(ServiceKey, new ClientOptions { Url = this.server.Url });
+        await admin.GetUser(UserToken);
+        this.server.VerifySingleReceivedRequest()
+            .WithHeader("Authorization", $"Bearer {UserToken}")
+            .WithoutHeader("apikey");
     }
 }

--- a/packages/Gotrue/Gotrue.Tests/Support/MockGotrueServer.cs
+++ b/packages/Gotrue/Gotrue.Tests/Support/MockGotrueServer.cs
@@ -83,6 +83,13 @@ internal sealed class ReceivedRequest
         return this;
     }
 
+    internal ReceivedRequest WithoutHeader(string name)
+    {
+        this.request.Headers!.Keys.Should().NotContain(key => string.Equals(key, name, StringComparison.OrdinalIgnoreCase),
+            $"'{name}' should not have been sent");
+        return this;
+    }
+
     internal ReceivedRequest WithJsonContentType()
     {
         this.request.Headers.Should().ContainKey("Content-Type").WhoseValue.Single().Should().StartWith("application/json");

--- a/packages/Gotrue/Gotrue/Api.cs
+++ b/packages/Gotrue/Gotrue/Api.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
@@ -523,11 +524,9 @@ public class Api : IGotrueApi<User, Session>
             ["Authorization"] = $"Bearer {jwt}"
         };
 
-        // New-format API keys (sb_publishable_/sb_secret_) are rejected on Authorization-only requests;
-        // the gateway requires an apikey header too. Preserve an apikey the caller already supplied (the
-        // stateful client injects the project key via GetHeaders — note the "apiKey" casing), otherwise
-        // fall back to the bearer token, matching supabase-js standalone admin usage.
-        if (!headers.Keys.Any(key => string.Equals(key, "apikey", StringComparison.OrdinalIgnoreCase)))
+        // Opaque keys need an apikey header too. Keep any configured key and never copy a JWT here (#424).
+        var hasApiKey = headers.Keys.Any(key => string.Equals(key, "apikey", StringComparison.OrdinalIgnoreCase));
+        if (!hasApiKey && !new JwtSecurityTokenHandler().CanReadToken(jwt))
             headers["apikey"] = jwt;
 
         return headers;


### PR DESCRIPTION
Closes #424.

The fallback added in #401 now only copies non-JWT credentials into apikey. Opaque sb_ keys keep the fallback; user tokens and legacy service-role JWTs don't.

Configured project keys are preserved. When none is configured, Api has no project key to fall back to, so JWTs only set Authorization, [matching that part of the JS behavior](https://github.com/supabase/supabase-js/blob/29b978d5da37cbb1927b1e8a8013c6f47e7223c8/packages/core/auth-js/src/lib/fetch.ts#L190-L192).
