### PR TITLE
fix(gotrue): keep the user from a sign-up awaiting confirmation

### DIFF
--- a/packages/Gotrue/Gotrue.Tests/Authentication/SignUpContractTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Authentication/SignUpContractTests.cs
@@ -1,5 +1,6 @@
 #region
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -7,6 +8,7 @@ using FluentAssertions.Execution;
 using Gotrue.Tests.Support;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Supabase.Gotrue;
+using Supabase.Gotrue.Exceptions;
 using Supabase.Gotrue.Interfaces;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -21,6 +23,7 @@ namespace Gotrue.Tests.Authentication;
 ///     Pins how SignUp treats the session the server returns. With email confirmations disabled the user is
 ///     auto-confirmed via <c>email_confirmed_at</c> (not <c>confirmed_at</c>), and the client must adopt that
 ///     session even though <c>AllowUnconfirmedUserSessions</c> is left at its default of false (issue #130).
+///     Pending signups return the user without adopting a session unless that option is enabled (issue #259).
 /// </summary>
 [TestClass]
 [TestCategory("Contract")]
@@ -44,6 +47,21 @@ public class SignUpContractTests
         }
         """;
 
+    private const string PendingConfirmationSignUp =
+        """
+        { "id": "user-id-259", "aud": "authenticated", "email": "pending@example.com", "confirmation_sent_at": "2026-06-09T09:15:57Z" }
+        """;
+
+    private const string PendingPhoneSignUp =
+        """
+        { "id": "user-id-259-phone", "aud": "authenticated", "phone": "15555550123", "confirmation_sent_at": "2026-06-09T09:15:57Z" }
+        """;
+
+    private const string Acknowledgement =
+        """
+        { "msg": "Confirmation link accepted. Please proceed to confirm link sent to the other email", "code": 200 }
+        """;
+
     private readonly List<Constants.AuthState> stateChanges = new();
     private IGotrueClient<User, Session> client = null!;
     private MockGotrueServer server = null!;
@@ -51,27 +69,74 @@ public class SignUpContractTests
     [TestInitialize]
     public void TestInitializer()
     {
-        server = new MockGotrueServer();
-        client = TestClients.Against(server);
-        client.AddStateChangedListener((_, state) => stateChanges.Add(state));
+        this.server = new MockGotrueServer();
+        this.client = TestClients.Against(this.server);
+        this.client.AddStateChangedListener((_, state) => this.stateChanges.Add(state));
     }
 
     [TestCleanup]
-    public void TestCleanup() => server.Dispose();
+    public void TestCleanup() => this.server.Dispose();
+
+    private void StubSignUp(string body) =>
+        this.server.Given(Request.Create().WithPath("/signup").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json").WithBody(body));
 
     [TestMethod]
     public async Task SignUp_ShouldAdoptTheSession_GivenAutoConfirmedUserAndDefaultOptions()
     {
-        server.Given(Request.Create().WithPath("/signup").UsingPost())
-            .RespondWith(Response.Create().WithStatusCode(200)
-                .WithHeader("Content-Type", "application/json").WithBody(AutoConfirmedSignUp));
-        await client.SignUp(RandomEmail(), Password);
+        this.StubSignUp(AutoConfirmedSignUp);
+        await this.client.SignUp(RandomEmail(), Password);
         using (new AssertionScope())
         {
-            client.CurrentSession.Should().NotBeNull(
+            this.client.CurrentSession.Should().NotBeNull(
                 "an auto-confirmed signup returns a usable session the client must adopt even with AllowUnconfirmedUserSessions off (issue #130)");
-            client.CurrentUser!.Id.Should().Be("user-id-130");
-            stateChanges.Should().Contain(SignedIn);
+            this.client.CurrentUser!.Id.Should().Be("user-id-130");
+            this.stateChanges.Should().Contain(SignedIn);
         }
+    }
+
+    [TestMethod]
+    public async Task SignUp_ShouldReturnTheUserWithoutSigningIn_GivenConfirmationRequired()
+    {
+        this.StubSignUp(PendingConfirmationSignUp);
+        var result = await this.client.SignUp(RandomEmail(), Password);
+        using (new AssertionScope())
+        {
+            result!.User!.Id.Should().Be("user-id-259", "a sign-up awaiting confirmation still returns its user (issue #259)");
+            result.AccessToken.Should().BeNull();
+            this.client.CurrentSession.Should().BeNull();
+            this.stateChanges.Should().NotContain(SignedIn);
+        }
+    }
+
+    [TestMethod]
+    public async Task SignUp_ShouldReturnNull_GivenAcknowledgementOnly()
+    {
+        this.StubSignUp(Acknowledgement);
+        (await this.client.SignUp(RandomEmail(), Password)).Should()
+            .BeNull("a body with no id is not a user, and must not be handed back as an empty one (issue #259)");
+    }
+
+    [TestMethod]
+    public async Task SignUp_ShouldAdoptPendingPhoneUser_GivenUnconfirmedSessionsAllowed()
+    {
+        this.StubSignUp(PendingPhoneSignUp);
+        this.client.Options.AllowUnconfirmedUserSessions = true;
+        await this.client.SignUp(Constants.SignUpType.Phone, "+15555550123", Password);
+        using (new AssertionScope())
+        {
+            this.client.CurrentUser!.Id.Should().Be("user-id-259-phone");
+            this.client.CurrentSession!.AccessToken.Should().BeNull("no token is granted until the user confirms");
+            this.stateChanges.Should().Contain(SignedIn);
+        }
+    }
+
+    [TestMethod]
+    public void SignUpWithPhone_ShouldThrowOnTheCall_GivenAnEmptyPhoneNumber()
+    {
+        // Not awaited: validation must throw on the call, not once the task is observed.
+        Action signUp = () => _ = new Api(this.server.Url).SignUpWithPhone(string.Empty, Password);
+        signUp.Should().Throw<GotrueException>();
     }
 }

--- a/packages/Gotrue/Gotrue.Tests/Authentication/VerifyOtpTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Authentication/VerifyOtpTests.cs
@@ -1,0 +1,40 @@
+#region
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Gotrue.Tests.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Gotrue;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+#endregion
+
+namespace Gotrue.Tests.Authentication;
+
+/// <summary>
+///     A secure email change is acknowledged with <c>{ msg, code }</c>, which VerifyOTP must report as null
+///     rather than read as a user (issue #259).
+/// </summary>
+[TestClass]
+[TestCategory("Contract")]
+public class VerifyOtpTests
+{
+    private const string EmailChangeAccepted =
+        """
+        { "msg": "Confirmation link accepted. Please proceed to confirm link sent to the other email", "code": 200 }
+        """;
+
+    [TestMethod]
+    public async Task VerifyOTP_ShouldReturnNull_GivenEmailChangeAcknowledgement()
+    {
+        using var server = new MockGotrueServer();
+        server.Given(Request.Create().WithPath("/verify").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json").WithBody(EmailChangeAccepted));
+        var client = TestClients.Against(server);
+        (await client.VerifyOTP("user@example.com", "123456", Constants.EmailOtpType.EmailChange)).Should()
+            .BeNull("the acknowledgement carries no session (issue #259)");
+        client.CurrentSession.Should().BeNull();
+    }
+}

--- a/packages/Gotrue/Gotrue.Tests/Stateless/StatelessSignUpTests.cs
+++ b/packages/Gotrue/Gotrue.Tests/Stateless/StatelessSignUpTests.cs
@@ -1,0 +1,53 @@
+#region
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Gotrue.Tests.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Gotrue;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using static Gotrue.Tests.TestUtils;
+using static Supabase.Gotrue.StatelessClient;
+
+#endregion
+
+namespace Gotrue.Tests.Stateless;
+
+/// <summary>
+///     Pending email and phone signups return the user without tokens (issue #259).
+/// </summary>
+[TestClass]
+[TestCategory("Contract")]
+public class StatelessSignUpTests
+{
+    private const string PendingEmailSignUp =
+        """
+        { "id": "user-id-259", "aud": "authenticated", "email": "pending@example.com", "confirmation_sent_at": "2026-06-09T09:15:57Z" }
+        """;
+
+    private const string PendingPhoneSignUp =
+        """
+        { "id": "user-id-259-phone", "aud": "authenticated", "phone": "15555550123", "confirmation_sent_at": "2026-06-09T09:15:57Z" }
+        """;
+
+    [TestMethod]
+    [DataRow(PendingEmailSignUp, Constants.SignUpType.Email, "pending@example.com", "user-id-259")]
+    [DataRow(PendingPhoneSignUp, Constants.SignUpType.Phone, "+15555550123", "user-id-259-phone")]
+    public async Task SignUp_ShouldReturnTheUserWithoutTokens_GivenConfirmationRequired(
+        string body, Constants.SignUpType type, string identifier, string expectedId)
+    {
+        using var server = new MockGotrueServer();
+        server.Given(Request.Create().WithPath("/signup").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json").WithBody(body));
+        var options = new StatelessClientOptions { Url = server.Url };
+        var result = await new StatelessClient().SignUp(type, identifier, Password, options);
+        using (new AssertionScope())
+        {
+            result!.User!.Id.Should().Be(expectedId, "a pending user must not be discarded (issue #259)");
+            result.AccessToken.Should().BeNull();
+        }
+    }
+}

--- a/packages/Gotrue/Gotrue/Api.cs
+++ b/packages/Gotrue/Gotrue/Api.cs
@@ -96,24 +96,36 @@ public class Api : IGotrueApi<User, Session>
             }
         }
 
-        var response = await this.MakeRequestAsync(HttpMethod.Post, endpoint, body, this.Headers);
+        return await this.PostSignUp(endpoint, body).ConfigureAwait(false);
+    }
 
-        if (!string.IsNullOrEmpty(response.Content))
+    private async Task<Session?> PostSignUp(string endpoint, Dictionary<string, object> body)
+    {
+        var response = await this.MakeRequestAsync(HttpMethod.Post, endpoint, body, this.Headers).ConfigureAwait(false);
+        return ReadSignUpResponse(response.Content);
+    }
+
+    /// <summary>Reads a sign-up response: a session, the bare user returned while confirmation is pending, or null.</summary>
+    private static Session? ReadSignUpResponse(string? content)
+    {
+        if (string.IsNullOrEmpty(content))
         {
-            // Gotrue returns a Session object for an auto-/pre-confirmed account
-            var session = JsonSerializer.Deserialize<Session>(response.Content!, Helpers.SerializerOptions);
-
-            // If account is unconfirmed, Gotrue returned the user object, so fill User data
-            // in from the parsed response.
-            if (session is { User: null })
-            {
-                // Gotrue returns a User object for an unconfirmed account
-                session.User = JsonSerializer.Deserialize<User>(response.Content!, Helpers.SerializerOptions);
-            }
-
-            return session;
+            return null;
         }
-        return null;
+
+        var session = JsonSerializer.Deserialize<Session>(content, Helpers.SerializerOptions);
+        if (session is { User: null })
+        {
+            // An acknowledgement such as { msg, code } must not become an empty User.
+            var user = JsonSerializer.Deserialize<User>(content, Helpers.SerializerOptions);
+            session.User = user?.Id != null ? user : null;
+            if (session.User == null && session.AccessToken == null)
+            {
+                return null;
+            }
+        }
+
+        return session;
     }
 
     /// <summary>
@@ -384,7 +396,7 @@ public class Api : IGotrueApi<User, Session>
             }
         }
 
-        return this.MakeRequestAsync<Session>(HttpMethod.Post, endpoint, body, this.Headers);
+        return this.PostSignUp(endpoint, body);
     }
 
     /// <summary>

--- a/packages/Gotrue/Gotrue/ClientOptions.cs
+++ b/packages/Gotrue/Gotrue/ClientOptions.cs
@@ -66,10 +66,10 @@ public class ClientOptions
     public int MaximumRefreshWaitTime { get; set; } = 14400;
 
     /// <summary>
-    /// Very unlikely this flag needs to be changed except in very specific contexts.
-    /// 
-    /// Enables tests to be E2E tests to be run without requiring users to have
-    /// confirmed emails - mirrors the Gotrue server's configuration.
+    /// Allows unconfirmed users to be treated as signed in. Defaults to false.
+    /// Sign-in returns null for an unconfirmed user unless this is on. During email or phone sign-up,
+    /// enabling this adopts the returned user in a session without tokens and raises
+    /// <see cref="Constants.AuthState.SignedIn" /> when confirmation is pending.
     /// </summary>
     public bool AllowUnconfirmedUserSessions { get; set; }
 }

--- a/packages/Gotrue/Gotrue/StatelessClient.cs
+++ b/packages/Gotrue/Gotrue/StatelessClient.cs
@@ -122,17 +122,13 @@ public class StatelessClient : IGotrueStatelessClient<User, Session>
     public async Task<Session?> SignUp(SignUpType type, string identifier, string password, StatelessClientOptions options, SignUpOptions? signUpOptions = null)
     {
         var api = this.GetApi(options);
-        var session = type switch
+        // Return pending users regardless of AllowUnconfirmedUserSessions; this client stores no session.
+        return type switch
         {
-            SignUpType.Email => await api.SignUpWithEmail(identifier, password, signUpOptions),
-            SignUpType.Phone => await api.SignUpWithPhone(identifier, password, signUpOptions),
+            SignUpType.Email => await api.SignUpWithEmail(identifier, password, signUpOptions).ConfigureAwait(false),
+            SignUpType.Phone => await api.SignUpWithPhone(identifier, password, signUpOptions).ConfigureAwait(false),
             _ => null,
         };
-        if (session?.User?.IsConfirmed == true || session?.User != null && options.AllowUnconfirmedUserSessions)
-        {
-            return session;
-        }
-        return null;
     }
 
     /// <inheritdoc />
@@ -357,9 +353,8 @@ public class StatelessClient : IGotrueStatelessClient<User, Session>
         public RetryOptions Retry { get; set; } = new RetryOptions();
 
         /// <summary>
-        ///     Very unlikely this flag needs to be changed except in very specific contexts.
-        ///     Enables tests to be E2E tests to be run without requiring users to have
-        ///     confirmed emails - mirrors the Gotrue server's configuration.
+        ///     Allows sign-in to return a session for an unconfirmed user. Defaults to false.
+        ///     Sign-up returns pending users regardless of this option.
         /// </summary>
         public bool AllowUnconfirmedUserSessions { get; set; }
     }


### PR DESCRIPTION
Closes #259

Pending email and phone sign-ups now both expose the user gotrue returns, the stateless client stops discarding it, and a response carrying neither a session nor a user no longer comes back as an empty one.